### PR TITLE
Adding CKF_CLOCK_ON_TOKEN binding.

### DIFF
--- a/pkcs11js.d.ts
+++ b/pkcs11js.d.ts
@@ -1178,6 +1178,7 @@ declare module "pkcs11js" {
     const CKF_WRAP: number;
     const CKF_UNWRAP: number;
     const CKF_DERIVE: number;
+    const CKF_CLOCK_ON_TOKEN: number;
 
     // Certificates
     const CKC_X_509: number;

--- a/src/const.cpp
+++ b/src/const.cpp
@@ -127,6 +127,7 @@ void declare_flags(Local<Object> target) {
 	SET_CONST(target, CKF_WRAP);
 	SET_CONST(target, CKF_UNWRAP);
 	SET_CONST(target, CKF_DERIVE);
+	SET_CONST(target, CKF_CLOCK_ON_TOKEN);
 }
 
 void declare_objects(Local<Object> target) {


### PR DESCRIPTION
Adding CKF_CLOCK_ON_TOKEN binding for use with Thales nShield HSMs