### PR TITLE
New values for CKM_AES_KEY_WRAP and CKM_AES_KEY_WRAP_PAD

### DIFF
--- a/includes/pkcs11/pkcs11t.h
+++ b/includes/pkcs11/pkcs11t.h
@@ -892,8 +892,8 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 
 #define CKM_AES_GCM                    0x00001087
 #define CKM_AES_CCM                    0x00001088
-#define CKM_AES_KEY_WRAP               0x00001090
-#define CKM_AES_KEY_WRAP_PAD           0x00001091
+#define CKM_AES_KEY_WRAP               0x00002109
+#define CKM_AES_KEY_WRAP_PAD           0x0000210a
 
 #define CKM_BLOWFISH_CBC_PAD           0x00001094
 #define CKM_TWOFISH_CBC_PAD            0x00001095


### PR DESCRIPTION
The latest PKCS #11 v2.40 specification, changes the values, because there was conflict with Blowfish in older version v2.30:

http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cs01/pkcs11-curr-v2.40-cs01.pdf

#define CKM_BLOWFISH_KEY_GEN 0x00001090
#define CKM_BLOWFISH_CBC 0x00001091
#define CKM_AES_KEY_WRAP 0x00002109
#define CKM_AES_KEY_WRAP_PAD 0x0000210A