### PR TITLE
Update binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,7 @@
                 [
                     'OS=="mac"', {
                         'xcode_settings': {
-                            'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++', '-v'],
+                            'OTHER_CPLUSPLUSFLAGS': ['-std=c++14', '-stdlib=libc++', '-v'],
                             'OTHER_CFLAGS': ['-ObjC++'],
                             'OTHER_LDFLAGS': ['-stdlib=libc++'],
                             'MACOSX_DEPLOYMENT_TARGET': '10.7',


### PR DESCRIPTION
Fix macOS build issue.

I got an error when I tried to build on macOS.

`error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
            !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);`

After changed `-std=c++11` to `-std=c++14`, everything works fine.