### PR TITLE
Fix #define STR_NONCE

### DIFF
--- a/src/pkcs11/strings.h
+++ b/src/pkcs11/strings.h
@@ -41,7 +41,7 @@
 #define STR_TAG_BITS "tagBits"
 #define STR_DATA "data"
 #define STR_DATA_LEN "dataLen"
-#define STR_NONCE "dataLen"
+#define STR_NONCE "nonce"
 #define STR_AAD "aad"
 #define STR_MAC_LEN "macLen"
 #define STR_HASH_ALG "hashAlg"


### PR DESCRIPTION
STR_NONCE is mistakenly defined as "dataLen".
https://github.com/PeculiarVentures/pkcs11js/blob/ed546c774e6008f219cfd771cdddc74edbdd30a0/src/pkcs11/strings.h#L43-L44

This results in failure of C_EncryptInit() under CKM_AES_CCM.
```
NativeError: Attribute 'nonce' MUST be NULL || BUFFER
```

This pull request is to fix STR_NONCE as "nonce", aligned with AesCCM.
https://github.com/PeculiarVentures/pkcs11js/blob/ed546c774e6008f219cfd771cdddc74edbdd30a0/index.d.ts#L278-L283