### PR TITLE
Add compiler c++17 indication needed for electron 21 rebuild

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -45,6 +45,7 @@
                         'msvs_settings': {
                             'VCCLCompilerTool': {
                                 'ExceptionHandling': 1,
+                                'AdditionalOptions': [ '-std:c++17', ],
                             }
                         }
                     }


### PR DESCRIPTION
Add a compiler indication needed for electron-rebuild with version 21 of electron. 

More details in [https://github.com/PeculiarVentures/pkcs11js/issues/95](https://github.com/PeculiarVentures/pkcs11js/issues/95)

I have run the test on windows and they are ok. I doesn't have access to other platform so i won't be able to test it.

Feel free to ask question if needed.