### PR TITLE
Fix memory access error in C_GetSlotList

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   build-os:

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,2216 +8,2479 @@
  * A Node.js implementation of the PKCS#11 2.30 interface
  */
 declare module "pkcs11js" {
+  /**
+   * PKCS#11 handle type
+   */
+  type Handle = Buffer;
+
+  /**
+   * Structure that describes the version
+   */
+  interface Version {
     /**
-     * PKCS#11 handle type
+     * Major version number (the integer portion of the version)
      */
-    type Handle = Buffer;
-
+    major: number;
     /**
-     * Structure that describes the version
+     * minor version number (the hundredths portion of the version)
      */
-    interface Version {
-        /**
-         * Major version number (the integer portion of the version)
-         */
-        major: number;
-        /**
-         * minor version number (the hundredths portion of the version)
-         */
-        minor: number;
-    }
+    minor: number;
+  }
 
+  /**
+   * Provides general information about Cryptoki
+   */
+  interface ModuleInfo {
     /**
-     * Provides general information about Cryptoki
+     * Cryptoki interface version number, for compatibility with future revisions of this interface
      */
-    interface ModuleInfo {
-        /**
-         * Cryptoki interface version number, for compatibility with future revisions of this interface
-         */
-        cryptokiVersion: Version;
-        /**
-         * ID of the Cryptoki library manufacturer.
-         * Must be padded with the blank character (' ').
-         */
-        manufacturerID: string;
-        /**
-         * Bit flags reserved for future versions. Must be zero for this version
-         */
-        flags: number;
-        /**
-         * Character-string description of the library.
-         * Must be padded with the blank character (' ')
-         */
-        libraryDescription: string;
-        /**
-         * Cryptoki library version number
-         */
-        libraryVersion: Version;
-    }
-
+    cryptokiVersion: Version;
     /**
-     * Provides information about a slot
+     * ID of the Cryptoki library manufacturer.
+     * Must be padded with the blank character (' ').
      */
-    interface SlotInfo {
-        /**
-         * Character-string description of the slot.
-         * Must be padded with the blank character (' ')
-         */
-        slotDescription: string;
-        /**
-         * ID of the slot manufacturer.
-         * Must be padded with the blank character (' ')
-         */
-        manufacturerID: string;
-        /**
-         * Bits flags that provide capabilities of the slot
-         */
-        flags: number;
-        /**
-         * Version number of the slot's hardware
-         */
-        hardwareVersion: Version;
-        /**
-         * Version number of the slot's firmware
-         */
-        firmwareVersion: Version;
-    }
-
+    manufacturerID: string;
     /**
-     * Provides information about a token
+     * Bit flags reserved for future versions. Must be zero for this version
      */
-    interface TokenInfo {
-        /**
-         * Application-defined label, assigned during token initialization.
-         * Must be padded with the blank character (' ')
-         */
-        label: string;
-        /**
-         * ID of the device manufacturer. 
-         * Must be padded with the blank character (' ')
-         */
-        manufacturerID: string;
-        /**
-         * Model of the device. 
-         * Must be padded with the blank character (' ')
-         */
-        model: string;
-        /**
-         * Character-string serial number of the device. 
-         * Must be padded with the blank character (' ')
-         */
-        serialNumber: string;
-        /**
-         * Bit flags indicating capabilities and status of the device
-         */
-        flags: number;
-        /**
-         * Maximum number of sessions that can be opened with the token at one time by a single application
-         */
-        maxSessionCount: number;
-        /**
-         * Number of sessions that this application currently has open with the token
-         */
-        sessionCount: number;
-        /**
-         * Maximum number of read/write sessions that can be opened with the token at one time by a single application
-         */
-        maxRwSessionCount: number;
-        /**
-         * Number of read/write sessions that this application currently has open with the token
-         */
-        rwSessionCount: number;
-        /**
-         * Maximum length in bytes of the PIN
-         */
-        maxPinLen: number;
-        /**
-         * Minimum length in bytes of the PIN
-         */
-        minPinLen: number;
-        /**
-         * version number of hardware
-         */
-        hardwareVersion: Version;
-        /**
-         * Version number of firmware
-         */
-        firmwareVersion: Version;
-        /**
-         * Current time as a character-string of length 16, represented in the format YYYYMMDDhhmmssxx 
-         * (4 characters for the year; 2 characters each for the month, the day, the hour, the minute, 
-         * and the second; and 2 additional reserved '0' characters). 
-         * The value of this field only makes sense for tokens equipped with a clock, 
-         * as indicated in the token information flags
-         */
-        utcTime: string;
-        /**
-         * The total amount of memory on the token in bytes in which public objects may be stored
-         */
-        totalPublicMemory: number;
-        /**
-         * The amount of free (unused) memory on the token in bytes for public objects
-         */
-        freePublicMemory: number;
-        /**
-         * The total amount of memory on the token in bytes in which private objects may be stored
-         */
-        totalPrivateMemory: number;
-        /**
-         * The amount of free (unused) memory on the token in bytes for private objects
-         */
-        freePrivateMemory: number;
-    }
-
+    flags: number;
     /**
-     * Provides information about a particular mechanism
+     * Character-string description of the library.
+     * Must be padded with the blank character (' ')
      */
-    interface MechanismInfo {
-        /**
-         * The minimum size of the key for the mechanism
-         */
-        minKeySize: number;
-        /**
-         * The maximum size of the key for the mechanism
-         */
-        maxKeySize: number;
-        /**
-         * Bit flags specifying mechanism capabilities
-         */
-        flags: number;
-    }
-
+    libraryDescription: string;
     /**
-     * Provides information about a session
+     * Cryptoki library version number
      */
-    interface SessionInfo {
-        /**
-         * ID of the slot that interfaces with the token
-         */
-        slotID: Buffer;
-        /**
-         * The state of the session
-         */
-        state: number;
-        /**
-         * Bit flags that define the type of session
-         */
-        flags: number;
-        /**
-         * An error code defined by the cryptographic device
-         */
-        deviceError: number;
-    }
+    libraryVersion: Version;
+  }
 
-    type Template = Attribute[];
-
-    interface AttributeResult {
-        type: number;
-        value: Buffer;
-    }
-
-    type TemplateResult = AttributeResult[];
-
+  /**
+   * Provides information about a slot
+   */
+  interface SlotInfo {
     /**
-     * A structure that includes the type and value of an attribute
+     * Character-string description of the slot.
+     * Must be padded with the blank character (' ')
      */
-    interface Attribute {
-        /**
-         * The attribute type
-         */
-        type: number;
-        /**
-         * The value of the attribute
-         */
-        value?: number | boolean | string | Buffer | Date;
-    }
-
+    slotDescription: string;
     /**
-     * A structure that specifies a particular mechanism and any parameters it requires
+     * ID of the slot manufacturer.
+     * Must be padded with the blank character (' ')
      */
-    interface Mechanism {
-        /**
-         * The type of mechanism
-         */
-        mechanism: number;
-        /**
-         * The parameter if required by the mechanism
-         */
-        parameter?: Buffer | number | IParams;
-    }
-
-    //#region Crypto parameters
-
+    manufacturerID: string;
     /**
-     * A base structure of a parameter
+     * Bits flags that provide capabilities of the slot
      */
-    interface IParams {
-        /**
-         * Type of crypto param. Uses constants CK_PARAMS_*
-         */
-        type: number;
-    }
-
+    flags: number;
     /**
-     * A structure that provides the parameters for the {@link CKM_ECDH1_DERIVE} and {@link CKM_ECDH1_COFACTOR_DERIVE} 
-     * key derivation mechanisms, where each party contributes one key pair
+     * Version number of the slot's hardware
      */
-    interface ECDH1 extends IParams {
-        /**
-         * Key derivation function used on the shared secret value
-         */
-        kdf: number;
-        /**
-         * Some data shared between the two parties
-         */
-        sharedData?: Buffer;
-        /**
-         * The other party's EC public key
-         */
-        publicData: Buffer;
-    }
-
-    interface AesCBC extends IParams {
-        iv: Buffer;
-        data?: Buffer;
-    }
-
-    interface AesCCM extends IParams {
-        dataLen: number;
-        nonce?: Buffer;
-        aad?: Buffer;
-        macLen: number;
-    }
-
-    interface AesGCM extends IParams {
-        iv?: Buffer;
-        aad?: Buffer;
-        ivBits: number;
-        tagBits: number;
-    }
-
-    interface RsaOAEP extends IParams {
-        hashAlg: number;
-        mgf: number;
-        source: number;
-        sourceData?: Buffer;
-    }
-
-    interface RsaPSS extends IParams {
-        hashAlg: number;
-        mgf: number;
-        saltLen: number;
-    }
-
-    interface Ecdh2Derive extends IParams {
-        kdf: number;
-        sharedData?: Buffer;
-        publicData: Buffer;
-        privateDataLen: number;
-        privateData: Handle;
-        publicData2?: Buffer;
-    }
-
-    interface EcmqvDerive extends IParams {
-        kdf: number;
-        sharedData?: Buffer;
-        publicData: Buffer;
-        privateDataLen: number;
-        publicData2?: Buffer;
-        privateData: Handle;
-    }
-
-    interface X942DH1Derive extends IParams {
-        kdf: number;
-        otherInfo?: Buffer;
-        publicData: Buffer;
-        privateData: Handle;
-    }
-
-    interface X942DH2Derive extends IParams {
-        kdf: number;
-        otherInfo?: Buffer;
-        publicData: Buffer;
-        privateData: Handle;
-        privateDataLen: number;
-        publicData2?: Buffer;
-    }
-
-    interface X942MQvDeriveParams {
-        kdf: number;
-        otherInfo?: Buffer;
-        publicData: Buffer;
-        privateData: Handle;
-        publicData2?: Buffer;
-        publicKey: Handle;
-    }
-
-    interface RC2CBCParams extends IParams {
-        effectiveBits: number;
-        iv: Buffer;
-    }
-
-    interface RC2MACGeneralParams extends IParams {
-        effectiveBits: number;
-        macLength: number;
-    }
-
-    interface RC5Params extends IParams {
-        wordSize: number;
-        rounds: number;
-    }
-
-    interface RC5CBCParams extends RC5Params {
-        wordSize: number;
-        rounds: number;
-        iv: Buffer;
-    }
-
-    interface RC5MACGeneralParams extends RC5Params {
-        wordSize: number;
-        rounds: number;
-        macLength: number;
-    }
-
-    interface DesCbcEncryptDataParams extends IParams {
-        iv: Buffer;
-        data?: Buffer;
-    }
-
-    interface SkipjackPrivateWrapParams extends IParams {
-        password: Buffer;
-        publicData: Buffer;
-        primeP: Buffer;
-        baseG: Buffer;
-        subprimeQ: Buffer;
-        randomA: Buffer;
-    }
-
-    interface SkipjackRelayXParams extends IParams {
-        oldWrappedX: Buffer;
-        oldPassword: Buffer;
-        oldPublicData: Buffer;
-        oldRandomA: Buffer;
-        newPassword: Buffer;
-        newPublicData: Buffer;
-        newRandomA: Buffer;
-    }
-
-    interface PbeParams extends IParams {
-        initVector: Buffer;
-        password: Buffer;
-        salt: Buffer;
-        iteration: number;
-    }
-
-    interface KeyWrapSetOaepParams extends IParams {
-        bc: number;
-        x: Buffer;
-    }
-
-    interface GcmParams extends IParams {
-        iv: Buffer;
-        ivBits: number;
-        aad?: Buffer;
-        tagBits?: number;
-    }
-
-    interface CcmParams extends IParams {
-        dataLen: number;
-        nonce?: Buffer;
-        aad?: Buffer;
-        macLen?: number;
-    }
-
-    interface GostR3410DeriveParams extends IParams {
-        kdf: number;
-        publicData: Buffer;
-        ukm?: Buffer;
-    }
-
-    interface GostR3410KeyWrapParams extends IParams {
-        wrapOID: Buffer;
-        ukm?: Buffer;
-        key: Handle;
-    }
-
-    //#endregion
-
-    interface KeyPair {
-        privateKey: Handle;
-        publicKey: Handle;
-    }
-
-    interface InitializationOptions {
-        /**
-         * NSS library parameters
-         */
-        libraryParameters?: string;
-        /**
-         * bit flags specifying options for {@link C_Initialize}
-         * - CKF_LIBRARY_CANT_CREATE_OS_THREADS. True if application threads which are executing calls to the library
-         *   may not use native operating system calls to spawn new threads; false if they may
-         * - CKF_OS_LOCKING_OK. True if the library can use the native operation system threading model for locking;
-         *   false otherwise
-         */
-        flags?: number;
-    }
-
+    hardwareVersion: Version;
     /**
-     * A Structure which contains a Cryptoki version and each function in the Cryptoki API
+     * Version number of the slot's firmware
      */
-    export class PKCS11 {
-        /**
-         * Library path
-         */
-        public libPath: string;
+    firmwareVersion: Version;
+  }
 
-        /**
-         * Creates an instance of PKCS11
-         * @param libPath The path to PKCS#11 library
-         */
-        constructor(libPath?: string);
+  /**
+   * Provides information about a token
+   */
+  interface TokenInfo {
+    /**
+     * Application-defined label, assigned during token initialization.
+     * Must be padded with the blank character (' ')
+     */
+    label: string;
+    /**
+     * ID of the device manufacturer.
+     * Must be padded with the blank character (' ')
+     */
+    manufacturerID: string;
+    /**
+     * Model of the device.
+     * Must be padded with the blank character (' ')
+     */
+    model: string;
+    /**
+     * Character-string serial number of the device.
+     * Must be padded with the blank character (' ')
+     */
+    serialNumber: string;
+    /**
+     * Bit flags indicating capabilities and status of the device
+     */
+    flags: number;
+    /**
+     * Maximum number of sessions that can be opened with the token at one time by a single application
+     */
+    maxSessionCount: number;
+    /**
+     * Number of sessions that this application currently has open with the token
+     */
+    sessionCount: number;
+    /**
+     * Maximum number of read/write sessions that can be opened with the token at one time by a single application
+     */
+    maxRwSessionCount: number;
+    /**
+     * Number of read/write sessions that this application currently has open with the token
+     */
+    rwSessionCount: number;
+    /**
+     * Maximum length in bytes of the PIN
+     */
+    maxPinLen: number;
+    /**
+     * Minimum length in bytes of the PIN
+     */
+    minPinLen: number;
+    /**
+     * version number of hardware
+     */
+    hardwareVersion: Version;
+    /**
+     * Version number of firmware
+     */
+    firmwareVersion: Version;
+    /**
+     * Current time as a character-string of length 16, represented in the format YYYYMMDDhhmmssxx
+     * (4 characters for the year; 2 characters each for the month, the day, the hour, the minute,
+     * and the second; and 2 additional reserved '0' characters).
+     * The value of this field only makes sense for tokens equipped with a clock,
+     * as indicated in the token information flags
+     */
+    utcTime: string;
+    /**
+     * The total amount of memory on the token in bytes in which public objects may be stored
+     */
+    totalPublicMemory: number;
+    /**
+     * The amount of free (unused) memory on the token in bytes for public objects
+     */
+    freePublicMemory: number;
+    /**
+     * The total amount of memory on the token in bytes in which private objects may be stored
+     */
+    totalPrivateMemory: number;
+    /**
+     * The amount of free (unused) memory on the token in bytes for private objects
+     */
+    freePrivateMemory: number;
+  }
 
-        /**
-         * Loads dynamic library with PKCS#11 interface
-         * @param path The path to PKCS#11 library
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public load(path: string): void;
-        /**
-         * Initializes the Cryptoki library
-         * @param options Initialization options
-         * Supports implementation of standard `CK_C_INITIALIZE_ARGS` and extended NSS format.
-         * - if `options` is null or empty, it calls native `C_Initialize` with `NULL`
-         * - if `options` doesn't have `libraryParameters`, it uses `CK_C_INITIALIZE_ARGS` structure
-         * - if `options` has `libraryParameters`, it uses extended NSS structure
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Initialize(options?: InitializationOptions): void;
-        /**
-         * Closes dynamic library
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public close(): void;
-        /**
-         * Indicates that an application is done with the Cryptoki library
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Finalize(): void;
-        /**
-         * Returns general information about Cryptoki
-         * @returns Information about Cryptoki
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetInfo(): ModuleInfo;
+  /**
+   * Provides information about a particular mechanism
+   */
+  interface MechanismInfo {
+    /**
+     * The minimum size of the key for the mechanism
+     */
+    minKeySize: number;
+    /**
+     * The maximum size of the key for the mechanism
+     */
+    maxKeySize: number;
+    /**
+     * Bit flags specifying mechanism capabilities
+     */
+    flags: number;
+  }
 
-        //#region Slot and token management
+  /**
+   * Provides information about a session
+   */
+  interface SessionInfo {
+    /**
+     * ID of the slot that interfaces with the token
+     */
+    slotID: Buffer;
+    /**
+     * The state of the session
+     */
+    state: number;
+    /**
+     * Bit flags that define the type of session
+     */
+    flags: number;
+    /**
+     * An error code defined by the cryptographic device
+     */
+    deviceError: number;
+  }
 
-        /**
-         * Obtains a list of slots in the system
-         * @param [tokenPresent] Only slots with tokens?
-         * @returns Array of slot IDs
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetSlotList(tokenPresent?: boolean): Handle[];
-        /**
-         * Obtains information about a particular slot in the system
-         * @param  slot The ID of the slot
-         * @returns Information about a slot
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetSlotInfo(slot: Handle): SlotInfo;
-        /**
-         * Obtains information about a particular token in the system
-         * @param slot ID of the token's slot
-         * @returns Information about a token
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetTokenInfo(slot: Handle): TokenInfo;
-        /**
-         * Initializes a token
-         * @param slot ID of the token's slot
-         * @param [pin] The SO's initial PIN
-         * @returns 32-byte token label (blank padded)
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_InitToken(slot: Handle, pin?: string, label?: string): string;
-        /**
-         * Initializes the normal user's PIN
-         * @param session The session's handle
-         * @param pin The normal user's PIN
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_InitPIN(session: Handle, pin?: string): void;
-        /**
-         * Modifies the PIN of the user who is logged in
-         * @param session The session's handle
-         * @param oldPin The old PIN
-         * @param newPin The new PIN
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SetPIN(session: Handle, oldPin: string, newPin: string): void;
-        /**
-         * Obtains a list of mechanism types supported by a token
-         * @param slot ID of token's slot
-         * @returns A list of mechanism types
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetMechanismList(slot: Handle): number[];
-        /**
-         * Obtains information about a particular mechanism possibly supported by a token
-         * @param slot ID of the token's slot
-         * @param mech Type of mechanism
-         * @returns Information about mechanism
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetMechanismInfo(slot: Handle, mech: number): MechanismInfo;
+  type Template = Attribute[];
 
-        //#endregion
+  interface AttributeResult {
+    type: number;
+    value: Buffer;
+  }
 
-        //#region Session management
+  type TemplateResult = AttributeResult[];
 
-        /**
-         * Opens a session between an application and a token
-         * @param slot The slot's ID
-         * @param flags From CK_SESSION_INFO
-         * @returns Session handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_OpenSession(slot: Handle, flags: number): Handle;
-        /**
-         * Closes a session between an application and a token
-         * @param session The session's handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_CloseSession(session: Handle): void;
-        /**
-         * Closes all sessions with a token
-         * @param slot The token's slot
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_CloseAllSessions(slot: Handle): void;
-        /**
-         * Obtains information about the session
-         * @param session The session's handle
-         * @returns Receives session info
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetSessionInfo(session: Handle): SessionInfo;
-        /**
-         * Logs a user into a token
-         * @param session The session's handle
-         * @param userType The user type
-         * @param [pin] The user's PIN
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Login(session: Handle, userType: number, pin?: string): void;
-        /**
-         * Logs a user out from a token
-         * @param session The session's handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Logout(session: Handle): void;
+  /**
+   * A structure that includes the type and value of an attribute
+   */
+  interface Attribute {
+    /**
+     * The attribute type
+     */
+    type: number;
+    /**
+     * The value of the attribute
+     */
+    value?: number | boolean | string | Buffer | Date;
+  }
 
-        //#endregion
+  /**
+   * A structure that specifies a particular mechanism and any parameters it requires
+   */
+  interface Mechanism {
+    /**
+     * The type of mechanism
+     */
+    mechanism: number;
+    /**
+     * The parameter if required by the mechanism
+     */
+    parameter?: Buffer | number | IParams;
+  }
 
-        //#region Object management
+  //#region Crypto parameters
 
-        /**
-         * Creates a new object
-         * @param session The session's handle
-         * @param template The object's template
-         * @returns A new object's handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_CreateObject(session: Handle, template: Template): Handle;
-        /**
-         * Copies an object, creating a new object for the copy
-         * @param session The session's handle
-         * @param object The object's handle
-         * @param template Template for new object
-         * @returns A handle of copy
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_CopyObject(session: Handle, object: Handle, template: Template): Handle;
-        /**
-         * Destroys an object
-         * @param session The session's handle
-         * @param object The object's handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DestroyObject(session: Handle, object: Handle): void;
-        /**
-         * Gets the size of an object in bytes
-         * @param session The session's handle
-         * @param object The object's handle
-         * @returns Size of an object in bytes
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetObjectSize(session: Handle, object: Handle): number;
-        /**
-         * Initializes a search for token and session objects that match a template
-         * @param session The session's handle
-         * @param template Attribute values to match
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_FindObjectsInit(session: Handle, template: Template): void;
-        /**
-         * Continues a search for token and session
-         * objects that match a template, obtaining additional object
-         * handles
-         * @param session The session's handle
-         * @param maxObjectCount The maximum number of object handles to be returned. Default value is 1.
-         * @returns List of handles
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_FindObjects(session: Handle, maxObjectCount: number): Handle[];
-        /**
-         * Continues a search for token and session
-         * objects that match a template, obtaining additional object
-         * handles
-         * @param session The session's handle
-         * @returns Object's handle. If object is not found
-         * the result is null
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_FindObjects(session: Handle): Handle | null;
-        /**
-         * Finishes a search for token and session objects
-         * @param session The session's handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_FindObjectsFinal(session: Handle): void;
-        /**
-         * Obtains the value of one or more object attributes
-         * @param session The session's handle
-         * @param object The object's handle
-         * @param template Specifies attrs; gets values
-         * @returns List of Attributes with values
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GetAttributeValue(session: Handle, object: Handle, template: Template): TemplateResult;
-        /**
-         * Modifies the value of one or more object attributes
-         * @param session The session's handle
-         * @param object The object's handle
-         * @param template Specifies attrs and values
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SetAttributeValue(session: Handle, object: Handle, template: Template): void;
+  /**
+   * A base structure of a parameter
+   */
+  interface IParams {
+    /**
+     * Type of crypto param. Uses constants CK_PARAMS_*
+     */
+    type: number;
+  }
 
-        //#endregion
+  /**
+   * A structure that provides the parameters for the {@link CKM_ECDH1_DERIVE} and {@link CKM_ECDH1_COFACTOR_DERIVE}
+   * key derivation mechanisms, where each party contributes one key pair
+   */
+  interface ECDH1 extends IParams {
+    /**
+     * Key derivation function used on the shared secret value
+     */
+    kdf: number;
+    /**
+     * Some data shared between the two parties
+     */
+    sharedData?: Buffer;
+    /**
+     * The other party's EC public key
+     */
+    publicData: Buffer;
+  }
 
-        //#region Encryption and decryption
+  interface AesCBC extends IParams {
+    iv: Buffer;
+    data?: Buffer;
+  }
 
-        /**
-         * Initializes an encryption operation
-         * @param session The session's handle
-         * @param mechanism The encryption mechanism
-         * @param key Handle of encryption key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_EncryptInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Encrypts single-part data
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data with encrypted message
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Encrypt(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Encrypts single-part data
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Encrypt(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Encrypts single-part data
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data with encrypted message
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_EncryptAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * Continues a multiple-part encryption operation
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_EncryptUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part encryption operation
-         * @param session The session's handle
-         * @param outData Last output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_EncryptFinal(session: Handle, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part encryption operation
-         * @param session The session's handle
-         * @param outData Last output data
-         * @param cb Async callback with sliced output data
-         */
-        public C_EncryptFinal(session: Handle, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Finishes a multiple-part encryption operation
-         * @param session The session's handle
-         * @param outData Last output data
-         * @returns Sliced output data
-         */
-        public C_EncryptFinalAsync(session: Handle, outData: Buffer): Promise<Buffer>;
-        /**
-         * Initializes a decryption operation
-         * @param session The session's handle
-         * @param mechanism The decryption mechanism
-         * @param key Handle of decryption key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DecryptInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Decrypts encrypted data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data with decrypted message
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Decrypt(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Decrypts encrypted data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Decrypt(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Decrypts encrypted data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data with decrypted message
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DecryptAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * continues a multiple-part decryption operation
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data with decrypted block
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DecryptUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part decryption operation
-         * @param session The session's handle
-         * @param outData Last part of output data
-         * @returns Sliced output data with decrypted final block
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DecryptFinal(session: Handle, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part decryption operation
-         * @param session The session's handle
-         * @param outData Last part of output data
-         * @param cb Async callback with sliced output data with decrypted final block
-         */
-        public C_DecryptFinal(session: Handle, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Finishes a multiple-part decryption operation
-         * @param session The session's handle
-         * @param outData Last part of output data
-         * @returns Sliced output data with decrypted final block
-         */
-        public C_DecryptFinalAsync(session: Handle, outData: Buffer): Promise<Buffer>;
+  interface AesCCM extends IParams {
+    dataLen: number;
+    nonce?: Buffer;
+    aad?: Buffer;
+    macLen: number;
+  }
 
-        /* Message digesting */
+  interface AesGCM extends IParams {
+    iv?: Buffer;
+    aad?: Buffer;
+    ivBits: number;
+    tagBits: number;
+  }
 
-        /**
-         * Initializes a message-digesting operation
-         * @param session The session's handle
-         * @param mechanism Digesting mechanism
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestInit(session: Handle, mechanism: Mechanism): void;
-        /**
-         * Digests data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Digest(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Digests data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Digest(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Digests data in a single part
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * continues a multiple-part message-digesting operation
-         * operation, by digesting the value of a secret key as part of
-         * the data already digested
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestUpdate(session: Handle, inData: Buffer): void;
-        /**
-         * Finishes a multiple-part message-digesting operation
-         * @param session The session's handle
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestFinal(session: Handle, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part message-digesting operation
-         * @param session The session's handle
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         */
-        public C_DigestFinal(session: Handle, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Finishes a multiple-part message-digesting operation
-         * @param session The session's handle
-         * @param outData Output data
-         * @returns Sliced output data
-         */
-        public C_DigestFinalAsync(session: Handle, outData: Buffer): Promise<Buffer>;
+  interface RsaOAEP extends IParams {
+    hashAlg: number;
+    mgf: number;
+    source: number;
+    sourceData?: Buffer;
+  }
 
-        /**
-         * Continues a multiple-part message-digesting operation by digesting the value of a secret key
-         * @param session The session's handle
-         * @param key The handle of the secret key to be digested
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestKey(session: Handle, key: Handle): void;
+  interface RsaPSS extends IParams {
+    hashAlg: number;
+    mgf: number;
+    saltLen: number;
+  }
 
-        //#endregion
+  interface Ecdh2Derive extends IParams {
+    kdf: number;
+    sharedData?: Buffer;
+    publicData: Buffer;
+    privateDataLen: number;
+    privateData: Handle;
+    publicData2?: Buffer;
+  }
 
-        //#region Signing and MACing
+  interface EcmqvDerive extends IParams {
+    kdf: number;
+    sharedData?: Buffer;
+    publicData: Buffer;
+    privateDataLen: number;
+    publicData2?: Buffer;
+    privateData: Handle;
+  }
 
-        /**
-         * initializes a signature (private key encryption)
-         * operation, where the signature is (will be) an appendix to
-         * the data, and plaintext cannot be recovered from the
-         * signature
-         * @param session The session's handle
-         * @param mechanism Signature mechanism
-         * @param key Handle of signature key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Signs (encrypts with private key) data in a single
-         * part, where the signature is (will be) an appendix to the
-         * data, and plaintext cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Sign(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Signs (encrypts with private key) data in a single
-         * part, where the signature is (will be) an appendix to the
-         * data, and plaintext cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Sign(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Signs (encrypts with private key) data in a single
-         * part, where the signature is (will be) an appendix to the
-         * data, and plaintext cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * Continues a multiple-part signature operation,
-         * where the signature is (will be) an appendix to the data,
-         * and plaintext cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignUpdate(session: Handle, inData: Buffer): void;
-        /**
-         * Finishes a multiple-part signature operation,
-         * returning the signature
-         * @param session The session's handle
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignFinal(session: Handle, outData: Buffer): Buffer;
-        /**
-         * Finishes a multiple-part signature operation,
-         * returning the signature
-         * @param session The session's handle
-         * @param outData Output data
-         * @param cb Async callback with sliced output data
-         */
-        public C_SignFinal(session: Handle, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Finishes a multiple-part signature operation,
-         * returning the signature
-         * @param session The session's handle
-         * @param outData Output data
-         * @returns Sliced output data
-         */
-        public C_SignFinalAsync(session: Handle, outData: Buffer): Promise<Buffer>;
+  interface X942DH1Derive extends IParams {
+    kdf: number;
+    otherInfo?: Buffer;
+    publicData: Buffer;
+    privateData: Handle;
+  }
 
-        /**
-         * Initializes a signature operation, where the data can be recovered from the signature
-         * @param session The session's handle
-         * @param mechanism The structure that specifies the signature mechanism 
-         * @param key The handle of the signature key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignRecoverInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Signs data in a single operation, where the data can be recovered from the signature
-         * @param session 
-         * @param inData Incoming data
-         * @param outData Output data
-         * @returns Sliced output data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignRecover(session: Handle, inData: Buffer, outData: Buffer): Buffer;
+  interface X942DH2Derive extends IParams {
+    kdf: number;
+    otherInfo?: Buffer;
+    publicData: Buffer;
+    privateData: Handle;
+    privateDataLen: number;
+    publicData2?: Buffer;
+  }
 
-        //#endregion
+  interface X942MQvDeriveParams {
+    kdf: number;
+    otherInfo?: Buffer;
+    publicData: Buffer;
+    privateData: Handle;
+    publicData2?: Buffer;
+    publicKey: Handle;
+  }
 
-        //#region Verifying signatures and MACs
+  interface RC2CBCParams extends IParams {
+    effectiveBits: number;
+    iv: Buffer;
+  }
 
-        /**
-         * initializes a verification operation, where the
-         * signature is an appendix to the data, and plaintext cannot
-         * cannot be recovered from the signature (e.g. DSA)
-         * @param session The session's handle
-         * @param mechanism Verification mechanism
-         * @param key Verification key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_VerifyInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Verifies a signature in a single-part operation,
-         * where the signature is an appendix to the data, and plaintext
-         * cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param signature Signature to verify
-         * @returns Verification result
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Verify(session: Handle, inData: Buffer, signature: Buffer): boolean;
-        /**
-         * Verifies a signature in a single-part operation,
-         * where the signature is an appendix to the data, and plaintext
-         * cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param signature Signature to verify
-         * @param cb Async callback with verification result
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_Verify(session: Handle, inData: Buffer, signature: Buffer, cb: (error: Error, verify: boolean) => void): void;
-        /**
-         * Verifies a signature in a single-part operation,
-         * where the signature is an appendix to the data, and plaintext
-         * cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @param signature Signature to verify
-         * @returns Verification result
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_VerifyAsync(session: Handle, inData: Buffer, signature: Buffer): Promise<boolean>;
-        /**
-         * Continues a multiple-part verification
-         * operation, where the signature is an appendix to the data,
-         * and plaintext cannot be recovered from the signature
-         * @param session The session's handle
-         * @param inData Incoming data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_VerifyUpdate(session: Handle, inData: Buffer): void;
-        /**
-         * Finishes a multiple-part verification
-         * operation, checking the signature
-         * @param session The session's handle
-         * @param signature Signature to verify
-         * @returns
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_VerifyFinal(session: Handle, signature: Buffer): boolean;
-        /**
-         * Finishes a multiple-part verification
-         * operation, checking the signature
-         * @param session The session's handle
-         * @param signature Signature to verify
-         * @param cb Async callback with verification result
-         */
-        public C_VerifyFinal(session: Handle, signature: Buffer, cb: (error: Error, verify: boolean) => void): void;
-        /**
-         * Finishes a multiple-part verification
-         * operation, checking the signature
-         * @param session The session's handle
-         * @param signature Signature to verify
-         * @returns Verification result
-         */
-        public C_VerifyFinalAsync(session: Handle, signature: Buffer): Promise<boolean>;
-        /**
-         * Initializes a signature verification operation, where the data is recovered from the signature
-         * @param session The session's handle
-         * @param mechanism The structure that specifies the verification mechanism
-         * @param key The handle of the verification key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        C_VerifyRecoverInit(session: Handle, mechanism: Mechanism, key: Handle): void;
-        /**
-         * Verifies a signature in a single-part operation, where the data is recovered from the signature
-         * @param session The session's handle
-         * @param signature The signature to verify
-         * @param outData The allocated buffer for recovered data
-         * @return The sliced output data with recovered data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        C_VerifyRecover(session: Handle, signature: Buffer, outData: Buffer): Buffer;
+  interface RC2MACGeneralParams extends IParams {
+    effectiveBits: number;
+    macLength: number;
+  }
 
-        //#endregion
+  interface RC5Params extends IParams {
+    wordSize: number;
+    rounds: number;
+  }
 
-        //#region Key management
+  interface RC5CBCParams extends RC5Params {
+    wordSize: number;
+    rounds: number;
+    iv: Buffer;
+  }
 
-        /**
-         * Generates a secret key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism Key generation mechanism
-         * @param template Template for new key
-         * @returns The handle of the new key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKey(session: Handle, mechanism: Mechanism, template: Template): Handle;
-        /**
-         * Generates a secret key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism Key generation mechanism
-         * @param template Template for new key
-         * @param cb Async callback with handle of new key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKey(session: Handle, mechanism: Mechanism, template: Template, cb: (error: Error, key: Handle) => void): void;
-        /**
-         * Generates a secret key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism The key generation mechanism
-         * @param template The template for the new key
-         * @returns The handle of the new key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKeyAsync(session: Handle, mechanism: Mechanism, template: Template): Promise<Handle>;
-        /**
-         * Generates a public-key/private-key pair,
-         * creating new key objects
-         * @param session The session's handle
-         * @param mechanism Key generation mechanism
-         * @param publicTmpl Template for public key
-         * @param privateTmpl Template for private key
-         * @returns The pair of handles for private and public keys
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKeyPair(session: Handle, mechanism: Mechanism, publicTmpl: Template, privateTmpl: Template): KeyPair;
-        /**
-         * Generates a public-key/private-key pair,
-         * creating new key objects
-         * @param session The session's handle
-         * @param mechanism Key generation mechanism
-         * @param publicTmpl Template for public key
-         * @param privateTmpl Template for private key
-         * @param cb Async callback with handles for private and public keys
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKeyPair(session: Handle, mechanism: Mechanism, publicTmpl: Template, privateTmpl: Template, cb: (error: Error, keys: KeyPair) => void): void;
-        /**
-         * Generates a public-key/private-key pair,
-         * creating new key objects
-         * @param session The session's handle
-         * @param mechanism Key generation mechanism
-         * @param publicTmpl Template for public key
-         * @param privateTmpl Template for private key
-         * @returns Handles for private and public keys
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateKeyPairAsync(session: Handle, mechanism: Mechanism, publicTmpl: Template, privateTmpl: Template): Promise<KeyPair>;
-        /**
-         * Wraps (i.e., encrypts) a key
-         * @param session The session's handle
-         * @param mechanism Wrapping mechanism
-         * @param wrappingKey Wrapping key
-         * @param key Key to be wrapped
-         * @param wrappedKey Init buffer for wrapped key
-         * @returns Sliced wrapped key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_WrapKey(session: Handle, mechanism: Mechanism, wrappingKey: Handle, key: Handle, wrappedKey: Buffer): Buffer;
-        /**
-         * Wraps (i.e., encrypts) a key
-         * @param session The session's handle
-         * @param mechanism Wrapping mechanism
-         * @param wrappingKey Wrapping key
-         * @param key Key to be wrapped
-         * @param wrappedKey Init buffer for wrapped key
-         * @param cb Async callback with sliced wrapped key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_WrapKey(session: Handle, mechanism: Mechanism, wrappingKey: Handle, key: Handle, wrappedKey: Buffer, cb: (error: Error, wrappedKey: Buffer) => void): void;
-        /**
-         * Wraps (i.e., encrypts) a key
-         * @param session The session's handle
-         * @param mechanism Wrapping mechanism
-         * @param wrappingKey Wrapping key
-         * @param key Key to be wrapped
-         * @param wrappedKey Init buffer for wrapped key
-         * @returns Sliced wrapped key
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_WrapKeyAsync(session: Handle, mechanism: Mechanism, wrappingKey: Handle, key: Handle, wrappedKey: Buffer): Promise<Buffer>;
-        /**
-         * Unwraps (decrypts) a wrapped key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism Unwrapping mechanism
-         * @param unwrappingKey Unwrapping key
-         * @param wrappedKey Wrapped key
-         * @param template New key template
-         * @returns The unwrapped key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_UnwrapKey(session: Handle, mechanism: Mechanism, unwrappingKey: Handle, wrappedKey: Buffer, template: Template): Handle;
-        /**
-         * Unwraps (decrypts) a wrapped key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism Unwrapping mechanism
-         * @param unwrappingKey Unwrapping key
-         * @param wrappedKey Wrapped key
-         * @param template New key template
-         * @param cb Async callback with new key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_UnwrapKey(session: Handle, mechanism: Mechanism, unwrappingKey: Handle, wrappedKey: Buffer, template: Template, cb: (error: Error, key: Handle) => void): void;
-        /**
-         * Unwraps (decrypts) a wrapped key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism Unwrapping mechanism
-         * @param unwrappingKey Unwrapping key
-         * @param wrappedKey Wrapped key
-         * @param template New key template
-         * @returns The unwrapped key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_UnwrapKeyAsync(session: Handle, mechanism: Mechanism, unwrappingKey: Handle, wrappedKey: Buffer, template: Template): Promise<Handle>;
-        /**
-         * Derives a key from a base key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism The key derivation mechanism
-         * @param key The base key
-         * @param template The template for the new key
-         * @returns The derived key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DeriveKey(session: Handle, mechanism: Mechanism, key: Handle, template: Template): Handle;
-        /**
-         * Derives a key from a base key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism The key derivation mechanism
-         * @param key The base key
-         * @param template The template for the new key
-         * @param cb Async callback with the derived key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DeriveKey(session: Handle, mechanism: Mechanism, key: Handle, template: Template, cb: (error: Error, hKey: Handle) => void): void;
-        /**
-         * Derives a key from a base key, creating a new key object
-         * @param session The session's handle
-         * @param mechanism The key derivation mechanism
-         * @param key The base key
-         * @param template The template for the new key
-         * @returns The derived key handle
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DeriveKeyAsync(session: Handle, mechanism: Mechanism, key: Handle, template: Template): Promise<Handle>;
-        /**
-         * Mixes additional seed material into the token's random number generator
-         * @param session The session's handle
-         * @param buf The seed material
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SeedRandom(session: Handle, buf: Buffer): void;
-        /**
-         * Generates random data
-         * @param session The session's handle
-         * @param buf Init buffer
-         * @returns The random data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_GenerateRandom(session: Handle, buf: Buffer): Buffer;
-        //#endregion
+  interface RC5MACGeneralParams extends RC5Params {
+    wordSize: number;
+    rounds: number;
+    macLength: number;
+  }
 
-        //#region Event management
-        /**
-         * Waits for a slot event, such as token insertion or token removal, to occur.
-         * @param flags Determines whether or not the C_WaitForSlotEvent call blocks (i.e., waits for a slot event to occur); use CKF_DONT_BLOCK for no blocking call
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         * @returns The slot ID where the event occurred, if successful; null otherwise
-         */
-        public C_WaitForSlotEvent(flags: number): Handle | null;
-        //#endregion
+  interface DesCbcEncryptDataParams extends IParams {
+    iv: Buffer;
+    data?: Buffer;
+  }
 
-        //#region Dual-function cryptographic operations
-        /**
-         * Continues a multiple-part digest and encryption
-         * operation (digesting and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be digested and encrypted
-         * @param outData Encrypted data
-         * @returns Sliced encrypted data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_DigestEncryptUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Continues a multiple-part digest and encryption
-         * operation (digesting and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be digested and encrypted
-         * @param outData Encrypted data
-         * @param cb Async callback with sliced encrypted data
-         */
-        public C_DigestEncryptUpdate(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Continues a multiple-part digest and encryption
-         * operation (digesting and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be digested and encrypted
-         * @param outData Encrypted data
-         * @returns Sliced encrypted data
-         */
-        public C_DigestEncryptUpdateAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * Continues a multiple-part decryption and digest
-         * operation (decrypting and digesting)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and digested
-         * @param outData Digested data
-         * @returns Sliced digested data
-         */
-        public C_DecryptDigestUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Continues a multiple-part decryption and digest
-         * operation (decrypting and digesting)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and digested
-         * @param outData Digested data
-         * @param cb Async callback with sliced digested data
-         */
-        public C_DecryptDigestUpdate(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Continues a multiple-part decryption and digest
-         * operation (decrypting and digesting)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and digested
-         * @param outData Digested data
-         * @returns Sliced digested data
-         */
-        public C_DecryptDigestUpdateAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * Continues a multiple-part signing and encryption
-         * operation (signing and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be signed and encrypted
-         * @param outData Encrypted data
-         * @returns Sliced encrypted data
-         * @throws {@link NativeError} if native error occurs
-         * @throws {@link Pkcs11Error} if Cryptoki error occurs
-         */
-        public C_SignEncryptUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Continues a multiple-part signing and encryption
-         * operation (signing and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be signed and encrypted
-         * @param outData Encrypted data
-         * @param cb Async callback with sliced encrypted data
-         */
-        public C_SignEncryptUpdate(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Continues a multiple-part signing and encryption
-         * operation (signing and encrypting)
-         * @param session The session's handle
-         * @param inData Data to be signed and encrypted
-         * @param outData Encrypted data
-         * @returns Sliced encrypted data
-         */
-        public C_SignEncryptUpdateAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        /**
-         * Continues a multiple-part decryption and
-         * verification operation (decrypting and verifying)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and verified
-         * @param outData Verified data
-         * @returns Sliced verified data
-         */
-        public C_DecryptVerifyUpdate(session: Handle, inData: Buffer, outData: Buffer): Buffer;
-        /**
-         * Continues a multiple-part decryption and
-         * verification operation (decrypting and verifying)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and verified
-         * @param outData Verified data
-         * @param cb Async callback with sliced verified data
-         */
-        public C_DecryptVerifyUpdate(session: Handle, inData: Buffer, outData: Buffer, cb: (error: Error, data: Buffer) => void): void;
-        /**
-         * Continues a multiple-part decryption and
-         * verification operation (decrypting and verifying)
-         * @param session The session's handle
-         * @param inData Data to be decrypted and verified
-         * @param outData Verified data
-         * @returns Sliced verified data
-         */
-        public C_DecryptVerifyUpdateAsync(session: Handle, inData: Buffer, outData: Buffer): Promise<Buffer>;
-        //#endregion
+  interface SkipjackPrivateWrapParams extends IParams {
+    password: Buffer;
+    publicData: Buffer;
+    primeP: Buffer;
+    baseG: Buffer;
+    subprimeQ: Buffer;
+    randomA: Buffer;
+  }
 
-    }
+  interface SkipjackRelayXParams extends IParams {
+    oldWrappedX: Buffer;
+    oldPassword: Buffer;
+    oldPublicData: Buffer;
+    oldRandomA: Buffer;
+    newPassword: Buffer;
+    newPublicData: Buffer;
+    newRandomA: Buffer;
+  }
 
-    //#region Attributes
-    const CKA_CLASS: number;
-    const CKA_TOKEN: number;
-    const CKA_PRIVATE: number;
-    const CKA_LABEL: number;
-    const CKA_APPLICATION: number;
-    const CKA_VALUE: number;
-    const CKA_OBJECT_ID: number;
-    const CKA_CERTIFICATE_TYPE: number;
-    const CKA_ISSUER: number;
-    const CKA_SERIAL_NUMBER: number;
-    const CKA_AC_ISSUER: number;
-    const CKA_OWNER: number;
-    const CKA_ATTR_TYPES: number;
-    const CKA_TRUSTED: number;
-    const CKA_CERTIFICATE_CATEGORY: number;
-    const CKA_JAVA_MIDP_SECURITY_DOMAIN: number;
-    const CKA_URL: number;
-    const CKA_HASH_OF_SUBJECT_PUBLIC_KEY: number;
-    const CKA_HASH_OF_ISSUER_PUBLIC_KEY: number;
-    const CKA_NAME_HASH_ALGORITHM: number;
-    const CKA_CHECK_VALUE: number;
-    const CKA_KEY_TYPE: number;
-    const CKA_SUBJECT: number;
-    const CKA_ID: number;
-    const CKA_SENSITIVE: number;
-    const CKA_ENCRYPT: number;
-    const CKA_DECRYPT: number;
-    const CKA_WRAP: number;
-    const CKA_UNWRAP: number;
-    const CKA_SIGN: number;
-    const CKA_SIGN_RECOVER: number;
-    const CKA_VERIFY: number;
-    const CKA_VERIFY_RECOVER: number;
-    const CKA_DERIVE: number;
-    const CKA_START_DATE: number;
-    const CKA_END_DATE: number;
-    const CKA_MODULUS: number;
-    const CKA_MODULUS_BITS: number;
-    const CKA_PUBLIC_EXPONENT: number;
-    const CKA_PRIVATE_EXPONENT: number;
-    const CKA_PRIME_1: number;
-    const CKA_PRIME_2: number;
-    const CKA_EXPONENT_1: number;
-    const CKA_EXPONENT_2: number;
-    const CKA_COEFFICIENT: number;
-    const CKA_PRIME: number;
-    const CKA_SUBPRIME: number;
-    const CKA_BASE: number;
-    const CKA_PRIME_BITS: number;
-    const CKA_SUBPRIME_BITS: number;
-    const CKA_SUB_PRIME_BITS: number;
-    const CKA_VALUE_BITS: number;
-    const CKA_VALUE_LEN: number;
-    const CKA_EXTRACTABLE: number;
-    const CKA_LOCAL: number;
-    const CKA_NEVER_EXTRACTABLE: number;
-    const CKA_ALWAYS_SENSITIVE: number;
-    const CKA_KEY_GEN_MECHANISM: number;
-    const CKA_MODIFIABLE: number;
-    const CKA_COPYABLE: number;
-    const CKA_DESTROYABLE: number;
-    const CKA_ECDSA_PARAMS: number;
-    const CKA_EC_PARAMS: number;
-    const CKA_EC_POINT: number;
-    const CKA_SECONDARY_AUTH: number;
-    const CKA_AUTH_PIN_FLAGS: number;
-    const CKA_ALWAYS_AUTHENTICATE: number;
-    const CKA_WRAP_WITH_TRUSTED: number;
-    const CKA_WRAP_TEMPLATE: number;
-    const CKA_UNWRAP_TEMPLATE: number;
-    const CKA_DERIVE_TEMPLATE: number;
-    const CKA_OTP_FORMAT: number;
-    const CKA_OTP_LENGTH: number;
-    const CKA_OTP_TIME_INTERVAL: number;
-    const CKA_OTP_USER_FRIENDLY_MODE: number;
-    const CKA_OTP_CHALLENGE_REQUIREMENT: number;
-    const CKA_OTP_TIME_REQUIREMENT: number;
-    const CKA_OTP_COUNTER_REQUIREMENT: number;
-    const CKA_OTP_PIN_REQUIREMENT: number;
-    const CKA_OTP_COUNTER: number;
-    const CKA_OTP_TIME: number;
-    const CKA_OTP_USER_IDENTIFIER: number;
-    const CKA_OTP_SERVICE_IDENTIFIER: number;
-    const CKA_OTP_SERVICE_LOGO: number;
-    const CKA_OTP_SERVICE_LOGO_TYPE: number;
-    const CKA_GOSTR3410_PARAMS: number;
-    const CKA_GOSTR3411_PARAMS: number;
-    const CKA_GOST28147_PARAMS: number;
-    const CKA_HW_FEATURE_TYPE: number;
-    const CKA_RESET_ON_INIT: number;
-    const CKA_HAS_RESET: number;
-    const CKA_PIXEL_X: number;
-    const CKA_PIXEL_Y: number;
-    const CKA_RESOLUTION: number;
-    const CKA_CHAR_ROWS: number;
-    const CKA_CHAR_COLUMNS: number;
-    const CKA_COLOR: number;
-    const CKA_BITS_PER_PIXEL: number;
-    const CKA_CHAR_SETS: number;
-    const CKA_ENCODING_METHODS: number;
-    const CKA_MIME_TYPES: number;
-    const CKA_MECHANISM_TYPE: number;
-    const CKA_REQUIRED_CMS_ATTRIBUTES: number;
-    const CKA_DEFAULT_CMS_ATTRIBUTES: number;
-    const CKA_SUPPORTED_CMS_ATTRIBUTES: number;
-    const CKA_ALLOWED_MECHANISMS: number;
-    const CKA_VENDOR_DEFINED: number;
-    //#endregion
+  interface PbeParams extends IParams {
+    initVector: Buffer;
+    password: Buffer;
+    salt: Buffer;
+    iteration: number;
+  }
 
-    //#region Objects
-    const CKO_DATA: number;
-    const CKO_CERTIFICATE: number;
-    const CKO_PUBLIC_KEY: number;
-    const CKO_PRIVATE_KEY: number;
-    const CKO_SECRET_KEY: number;
-    const CKO_HW_FEATURE: number;
-    const CKO_DOMAIN_PARAMETERS: number;
-    const CKO_MECHANISM: number;
-    const CKO_OTP_KEY: number;
-    const CKO_VENDOR_DEFINED: number;
-    //#endregion
+  interface KeyWrapSetOaepParams extends IParams {
+    bc: number;
+    x: Buffer;
+  }
 
-    //#region Key types
-    const CKK_RSA: number;
-    const CKK_DSA: number;
-    const CKK_DH: number;
-    const CKK_ECDSA: number;
-    const CKK_EC: number;
-    const CKK_X9_42_DH: number;
-    const CKK_KEA: number;
-    const CKK_GENERIC_SECRET: number;
-    const CKK_RC2: number;
-    const CKK_RC4: number;
-    const CKK_DES: number;
-    const CKK_DES2: number;
-    const CKK_DES3: number;
-    const CKK_CAST: number;
-    const CKK_CAST3: number;
-    const CKK_CAST5: number;
-    const CKK_CAST128: number;
-    const CKK_RC5: number;
-    const CKK_IDEA: number;
-    const CKK_SKIPJACK: number;
-    const CKK_BATON: number;
-    const CKK_JUNIPER: number;
-    const CKK_CDMF: number;
-    const CKK_AES: number;
-    const CKK_BLOWFISH: number;
-    const CKK_TWOFISH: number;
-    const CKK_SECURID: number;
-    const CKK_HOTP: number;
-    const CKK_ACTI: number;
-    const CKK_CAMELLIA: number;
-    const CKK_ARIA: number;
-    const CKK_MD5_HMAC: number;
-    const CKK_SHA_1_HMAC: number;
-    const CKK_RIPEMD128_HMAC: number;
-    const CKK_RIPEMD160_HMAC: number;
-    const CKK_SHA256_HMAC: number;
-    const CKK_SHA384_HMAC: number;
-    const CKK_SHA512_HMAC: number;
-    const CKK_SHA224_HMAC: number;
-    const CKK_SEED: number;
-    const CKK_GOSTR3410: number;
-    const CKK_GOSTR3411: number;
-    const CKK_GOST28147: number;
-    const CKK_VENDOR_DEFINED: number;
-    //#endregion
+  interface GcmParams extends IParams {
+    iv: Buffer;
+    ivBits: number;
+    aad?: Buffer;
+    tagBits?: number;
+  }
 
-    //#region Mechanisms
-    const CKM_RSA_PKCS_KEY_PAIR_GEN: number;
-    const CKM_RSA_PKCS: number;
-    const CKM_RSA_9796: number;
-    const CKM_RSA_X_509: number;
-    const CKM_MD2_RSA_PKCS: number;
-    const CKM_MD5_RSA_PKCS: number;
-    const CKM_SHA1_RSA_PKCS: number;
-    const CKM_RIPEMD128_RSA_PKCS: number;
-    const CKM_RIPEMD160_RSA_PKCS: number;
-    const CKM_RSA_PKCS_OAEP: number;
-    const CKM_RSA_X9_31_KEY_PAIR_GEN: number;
-    const CKM_RSA_X9_31: number;
-    const CKM_SHA1_RSA_X9_31: number;
-    const CKM_RSA_PKCS_PSS: number;
-    const CKM_SHA1_RSA_PKCS_PSS: number;
-    const CKM_DSA_KEY_PAIR_GEN: number;
-    const CKM_DSA: number;
-    const CKM_DSA_SHA1: number;
-    const CKM_DSA_SHA224: number;
-    const CKM_DSA_SHA256: number;
-    const CKM_DSA_SHA384: number;
-    const CKM_DSA_SHA512: number;
-    const CKM_DH_PKCS_KEY_PAIR_GEN: number;
-    const CKM_DH_PKCS_DERIVE: number;
-    const CKM_X9_42_DH_KEY_PAIR_GEN: number;
-    const CKM_X9_42_DH_DERIVE: number;
-    const CKM_X9_42_DH_HYBRID_DERIVE: number;
-    const CKM_X9_42_MQV_DERIVE: number;
-    const CKM_SHA256_RSA_PKCS: number;
-    const CKM_SHA384_RSA_PKCS: number;
-    const CKM_SHA512_RSA_PKCS: number;
-    const CKM_SHA256_RSA_PKCS_PSS: number;
-    const CKM_SHA384_RSA_PKCS_PSS: number;
-    const CKM_SHA512_RSA_PKCS_PSS: number;
-    const CKM_SHA224_RSA_PKCS: number;
-    const CKM_SHA224_RSA_PKCS_PSS: number;
-    const CKM_RC2_KEY_GEN: number;
-    const CKM_RC2_ECB: number;
-    const CKM_RC2_CBC: number;
-    const CKM_RC2_MAC: number;
-    const CKM_RC2_MAC_GENERAL: number;
-    const CKM_RC2_CBC_PAD: number;
-    const CKM_RC4_KEY_GEN: number;
-    const CKM_RC4: number;
-    const CKM_DES_KEY_GEN: number;
-    const CKM_DES_ECB: number;
-    const CKM_DES_CBC: number;
-    const CKM_DES_MAC: number;
-    const CKM_DES_MAC_GENERAL: number;
-    const CKM_DES_CBC_PAD: number;
-    const CKM_DES2_KEY_GEN: number;
-    const CKM_DES3_KEY_GEN: number;
-    const CKM_DES3_ECB: number;
-    const CKM_DES3_CBC: number;
-    const CKM_DES3_MAC: number;
-    const CKM_DES3_MAC_GENERAL: number;
-    const CKM_DES3_CBC_PAD: number;
-    const CKM_DES3_CMAC_GENERAL: number;
-    const CKM_DES3_CMAC: number;
-    const CKM_CDMF_KEY_GEN: number;
-    const CKM_CDMF_ECB: number;
-    const CKM_CDMF_CBC: number;
-    const CKM_CDMF_MAC: number;
-    const CKM_CDMF_MAC_GENERAL: number;
-    const CKM_CDMF_CBC_PAD: number;
-    const CKM_DES_OFB64: number;
-    const CKM_DES_OFB8: number;
-    const CKM_DES_CFB64: number;
-    const CKM_DES_CFB8: number;
-    const CKM_MD2: number;
-    const CKM_MD2_HMAC: number;
-    const CKM_MD2_HMAC_GENERAL: number;
-    const CKM_MD5: number;
-    const CKM_MD5_HMAC: number;
-    const CKM_MD5_HMAC_GENERAL: number;
-    const CKM_SHA_1: number;
-    const CKM_SHA_1_HMAC: number;
-    const CKM_SHA_1_HMAC_GENERAL: number;
-    const CKM_RIPEMD128: number;
-    const CKM_RIPEMD128_HMAC: number;
-    const CKM_RIPEMD128_HMAC_GENERAL: number;
-    const CKM_RIPEMD160: number;
-    const CKM_RIPEMD160_HMAC: number;
-    const CKM_RIPEMD160_HMAC_GENERAL: number;
-    const CKM_SHA256: number;
-    const CKM_SHA256_HMAC: number;
-    const CKM_SHA256_HMAC_GENERAL: number;
-    const CKM_SHA224: number;
-    const CKM_SHA224_HMAC: number;
-    const CKM_SHA224_HMAC_GENERAL: number;
-    const CKM_SHA384: number;
-    const CKM_SHA384_HMAC: number;
-    const CKM_SHA384_HMAC_GENERAL: number;
-    const CKM_SHA512: number;
-    const CKM_SHA512_HMAC: number;
-    const CKM_SHA512_HMAC_GENERAL: number;
-    const CKM_SECURID_KEY_GEN: number;
-    const CKM_SECURID: number;
-    const CKM_HOTP_KEY_GEN: number;
-    const CKM_HOTP: number;
-    const CKM_ACTI: number;
-    const CKM_ACTI_KEY_GEN: number;
-    const CKM_CAST_KEY_GEN: number;
-    const CKM_CAST_ECB: number;
-    const CKM_CAST_CBC: number;
-    const CKM_CAST_MAC: number;
-    const CKM_CAST_MAC_GENERAL: number;
-    const CKM_CAST_CBC_PAD: number;
-    const CKM_CAST3_KEY_GEN: number;
-    const CKM_CAST3_ECB: number;
-    const CKM_CAST3_CBC: number;
-    const CKM_CAST3_MAC: number;
-    const CKM_CAST3_MAC_GENERAL: number;
-    const CKM_CAST3_CBC_PAD: number;
-    const CKM_CAST5_KEY_GEN: number;
-    const CKM_CAST128_KEY_GEN: number;
-    const CKM_CAST5_ECB: number;
-    const CKM_CAST128_ECB: number;
-    const CKM_CAST5_CBC: number;
-    const CKM_CAST128_CBC: number;
-    const CKM_CAST5_MAC: number;
-    const CKM_CAST128_MAC: number;
-    const CKM_CAST5_MAC_GENERAL: number;
-    const CKM_CAST128_MAC_GENERAL: number;
-    const CKM_CAST5_CBC_PAD: number;
-    const CKM_CAST128_CBC_PAD: number;
-    const CKM_RC5_KEY_GEN: number;
-    const CKM_RC5_ECB: number;
-    const CKM_RC5_CBC: number;
-    const CKM_RC5_MAC: number;
-    const CKM_RC5_MAC_GENERAL: number;
-    const CKM_RC5_CBC_PAD: number;
-    const CKM_IDEA_KEY_GEN: number;
-    const CKM_IDEA_ECB: number;
-    const CKM_IDEA_CBC: number;
-    const CKM_IDEA_MAC: number;
-    const CKM_IDEA_MAC_GENERAL: number;
-    const CKM_IDEA_CBC_PAD: number;
-    const CKM_GENERIC_SECRET_KEY_GEN: number;
-    const CKM_CONCATENATE_BASE_AND_KEY: number;
-    const CKM_CONCATENATE_BASE_AND_DATA: number;
-    const CKM_CONCATENATE_DATA_AND_BASE: number;
-    const CKM_XOR_BASE_AND_DATA: number;
-    const CKM_EXTRACT_KEY_FROM_KEY: number;
-    const CKM_SSL3_PRE_MASTER_KEY_GEN: number;
-    const CKM_SSL3_MASTER_KEY_DERIVE: number;
-    const CKM_SSL3_KEY_AND_MAC_DERIVE: number;
-    const CKM_SSL3_MASTER_KEY_DERIVE_DH: number;
-    const CKM_TLS_PRE_MASTER_KEY_GEN: number;
-    const CKM_TLS_MASTER_KEY_DERIVE: number;
-    const CKM_TLS_KEY_AND_MAC_DERIVE: number;
-    const CKM_TLS_MASTER_KEY_DERIVE_DH: number;
-    const CKM_TLS_PRF: number;
-    const CKM_SSL3_MD5_MAC: number;
-    const CKM_SSL3_SHA1_MAC: number;
-    const CKM_MD5_KEY_DERIVATION: number;
-    const CKM_MD2_KEY_DERIVATION: number;
-    const CKM_SHA1_KEY_DERIVATION: number;
-    const CKM_SHA256_KEY_DERIVATION: number;
-    const CKM_SHA384_KEY_DERIVATION: number;
-    const CKM_SHA512_KEY_DERIVATION: number;
-    const CKM_SHA224_KEY_DERIVATION: number;
-    const CKM_PBE_MD2_DES_CBC: number;
-    const CKM_PBE_MD5_DES_CBC: number;
-    const CKM_PBE_MD5_CAST_CBC: number;
-    const CKM_PBE_MD5_CAST3_CBC: number;
-    const CKM_PBE_MD5_CAST5_CBC: number;
-    const CKM_PBE_MD5_CAST128_CBC: number;
-    const CKM_PBE_SHA1_CAST5_CBC: number;
-    const CKM_PBE_SHA1_CAST128_CBC: number;
-    const CKM_PBE_SHA1_RC4_128: number;
-    const CKM_PBE_SHA1_RC4_40: number;
-    const CKM_PBE_SHA1_DES3_EDE_CBC: number;
-    const CKM_PBE_SHA1_DES2_EDE_CBC: number;
-    const CKM_PBE_SHA1_RC2_128_CBC: number;
-    const CKM_PBE_SHA1_RC2_40_CBC: number;
-    const CKM_PKCS5_PBKD2: number;
-    const CKM_PBA_SHA1_WITH_SHA1_HMAC: number;
-    const CKM_WTLS_PRE_MASTER_KEY_GEN: number;
-    const CKM_WTLS_MASTER_KEY_DERIVE: number;
-    const CKM_WTLS_MASTER_KEY_DERIVE_DH_ECC: number;
-    const CKM_WTLS_PRF: number;
-    const CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE: number;
-    const CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE: number;
-    const CKM_KEY_WRAP_LYNKS: number;
-    const CKM_KEY_WRAP_SET_OAEP: number;
-    const CKM_CAMELLIA_KEY_GEN: number;
-    const CKM_CAMELLIA_ECB: number;
-    const CKM_CAMELLIA_CBC: number;
-    const CKM_CAMELLIA_MAC: number;
-    const CKM_CAMELLIA_MAC_GENERAL: number;
-    const CKM_CAMELLIA_CBC_PAD: number;
-    const CKM_CAMELLIA_ECB_ENCRYPT_DATA: number;
-    const CKM_CAMELLIA_CBC_ENCRYPT_DATA: number;
-    const CKM_CAMELLIA_CTR: number;
-    const CKM_ARIA_KEY_GEN: number;
-    const CKM_ARIA_ECB: number;
-    const CKM_ARIA_CBC: number;
-    const CKM_ARIA_MAC: number;
-    const CKM_ARIA_MAC_GENERAL: number;
-    const CKM_ARIA_CBC_PAD: number;
-    const CKM_ARIA_ECB_ENCRYPT_DATA: number;
-    const CKM_ARIA_CBC_ENCRYPT_DATA: number;
-    const CKM_SEED_KEY_GEN: number;
-    const CKM_SEED_ECB: number;
-    const CKM_SEED_CBC: number;
-    const CKM_SEED_MAC: number;
-    const CKM_SEED_MAC_GENERAL: number;
-    const CKM_SEED_CBC_PAD: number;
-    const CKM_SEED_ECB_ENCRYPT_DATA: number;
-    const CKM_SEED_CBC_ENCRYPT_DATA: number;
-    const CKM_SKIPJACK_KEY_GEN: number;
-    const CKM_SKIPJACK_ECB64: number;
-    const CKM_SKIPJACK_CBC64: number;
-    const CKM_SKIPJACK_OFB64: number;
-    const CKM_SKIPJACK_CFB64: number;
-    const CKM_SKIPJACK_CFB32: number;
-    const CKM_SKIPJACK_CFB16: number;
-    const CKM_SKIPJACK_CFB8: number;
-    const CKM_SKIPJACK_WRAP: number;
-    const CKM_SKIPJACK_PRIVATE_WRAP: number;
-    const CKM_SKIPJACK_RELAYX: number;
-    const CKM_KEA_KEY_PAIR_GEN: number;
-    const CKM_KEA_KEY_DERIVE: number;
-    const CKM_FORTEZZA_TIMESTAMP: number;
-    const CKM_BATON_KEY_GEN: number;
-    const CKM_BATON_ECB128: number;
-    const CKM_BATON_ECB96: number;
-    const CKM_BATON_CBC128: number;
-    const CKM_BATON_COUNTER: number;
-    const CKM_BATON_SHUFFLE: number;
-    const CKM_BATON_WRAP: number;
-    const CKM_ECDSA_KEY_PAIR_GEN: number;
-    const CKM_EC_KEY_PAIR_GEN: number;
-    const CKM_ECDSA: number;
-    const CKM_ECDSA_SHA1: number;
-    const CKM_ECDSA_SHA224: number;
-    const CKM_ECDSA_SHA256: number;
-    const CKM_ECDSA_SHA384: number;
-    const CKM_ECDSA_SHA512: number;
-    const CKM_ECDH1_DERIVE: number;
-    const CKM_ECDH1_COFACTOR_DERIVE: number;
-    const CKM_ECMQV_DERIVE: number;
-    const CKM_JUNIPER_KEY_GEN: number;
-    const CKM_JUNIPER_ECB128: number;
-    const CKM_JUNIPER_CBC128: number;
-    const CKM_JUNIPER_COUNTER: number;
-    const CKM_JUNIPER_SHUFFLE: number;
-    const CKM_JUNIPER_WRAP: number;
-    const CKM_FASTHASH: number;
-    const CKM_AES_KEY_GEN: number;
-    const CKM_AES_ECB: number;
-    const CKM_AES_CBC: number;
-    const CKM_AES_MAC: number;
-    const CKM_AES_MAC_GENERAL: number;
-    const CKM_AES_CBC_PAD: number;
-    const CKM_AES_CTR: number;
-    const CKM_AES_CTS: number;
-    const CKM_AES_CMAC: number;
-    const CKM_AES_CMAC_GENERAL: number;
-    const CKM_BLOWFISH_KEY_GEN: number;
-    const CKM_BLOWFISH_CBC: number;
-    const CKM_TWOFISH_KEY_GEN: number;
-    const CKM_TWOFISH_CBC: number;
-    const CKM_AES_GCM: number;
-    const CKM_AES_CCM: number;
-    const CKM_AES_KEY_WRAP: number;
-    const CKM_AES_KEY_WRAP_PAD: number;
-    const CKM_BLOWFISH_CBC_PAD: number;
-    const CKM_TWOFISH_CBC_PAD: number;
-    const CKM_DES_ECB_ENCRYPT_DATA: number;
-    const CKM_DES_CBC_ENCRYPT_DATA: number;
-    const CKM_DES3_ECB_ENCRYPT_DATA: number;
-    const CKM_DES3_CBC_ENCRYPT_DATA: number;
-    const CKM_AES_ECB_ENCRYPT_DATA: number;
-    const CKM_AES_CBC_ENCRYPT_DATA: number;
-    const CKM_GOSTR3410_KEY_PAIR_GEN: number;
-    const CKM_GOSTR3410: number;
-    const CKM_GOSTR3410_WITH_GOSTR3411: number;
-    const CKM_GOSTR3410_KEY_WRAP: number;
-    const CKM_GOSTR3410_DERIVE: number;
-    const CKM_GOSTR3411: number;
-    const CKM_GOSTR3411_HMAC: number;
-    const CKM_GOST28147_KEY_GEN: number;
-    const CKM_GOST28147_ECB: number;
-    const CKM_GOST28147: number;
-    const CKM_GOST28147_MAC: number;
-    const CKM_GOST28147_KEY_WRAP: number;
-    const CKM_DSA_PARAMETER_GEN: number;
-    const CKM_DH_PKCS_PARAMETER_GEN: number;
-    const CKM_X9_42_DH_PARAMETER_GEN: number;
-    const CKM_AES_OFB: number;
-    const CKM_AES_CFB64: number;
-    const CKM_AES_CFB8: number;
-    const CKM_AES_CFB128: number;
-    const CKM_RSA_PKCS_TPM_1_1: number;
-    const CKM_RSA_PKCS_OAEP_TPM_1_1: number;
-    const CKM_VENDOR_DEFINED: number;
-    //#endregion
+  interface CcmParams extends IParams {
+    dataLen: number;
+    nonce?: Buffer;
+    aad?: Buffer;
+    macLen?: number;
+  }
 
-    //#region Session flags
-    const CKF_RW_SESSION: number;
-    const CKF_SERIAL_SESSION: number;
-    //#endregion
+  interface GostR3410DeriveParams extends IParams {
+    kdf: number;
+    publicData: Buffer;
+    ukm?: Buffer;
+  }
 
-    //#region Mechanism flags
-    const CKF_HW: number;
-    const CKF_ENCRYPT: number;
-    const CKF_DECRYPT: number;
-    const CKF_DIGEST: number;
-    const CKF_SIGN: number;
-    const CKF_SIGN_RECOVER: number;
-    const CKF_VERIFY: number;
-    const CKF_VERIFY_RECOVER: number;
-    const CKF_GENERATE: number;
-    const CKF_GENERATE_KEY_PAIR: number;
-    const CKF_WRAP: number;
-    const CKF_UNWRAP: number;
-    const CKF_DERIVE: number;
-    //#endregion
+  interface GostR3410KeyWrapParams extends IParams {
+    wrapOID: Buffer;
+    ukm?: Buffer;
+    key: Handle;
+  }
 
-    //#region Token Information Flags
-    const CKF_RNG: number;
-    const CKF_WRITE_PROTECTED: number;
-    const CKF_LOGIN_REQUIRED: number;
-    const CKF_USER_PIN_INITIALIZED: number;
-    const CKF_RESTORE_KEY_NOT_NEEDED: number;
-    const CKF_CLOCK_ON_TOKEN: number;
-    const CKF_PROTECTED_AUTHENTICATION_PATH: number;
-    const CKF_DUAL_CRYPTO_OPERATIONS: number;
-    const CKF_TOKEN_INITIALIZED: number;
-    const CKF_SECONDARY_AUTHENTICATION: number;
-    const CKF_USER_PIN_COUNT_LOW: number;
-    const CKF_USER_PIN_FINAL_TRY: number;
-    const CKF_USER_PIN_LOCKED: number;
-    const CKF_USER_PIN_TO_BE_CHANGED: number;
-    const CKF_SO_PIN_COUNT_LOW: number;
-    const CKF_SO_PIN_FINAL_TRY: number;
-    const CKF_SO_PIN_LOCKED: number;
-    const CKF_SO_PIN_TO_BE_CHANGED: number;
-    const CKF_ERROR_STATE: number;
-    //#endregion
+  //#endregion
 
-    //#region Event Flags
-    const CKF_DONT_BLOCK: number;
-    //#endregion
+  interface KeyPair {
+    privateKey: Handle;
+    publicKey: Handle;
+  }
 
-    //#region Certificates
-    const CKC_X_509: number;
-    const CKC_X_509_ATTR_CERT: number;
-    const CKC_WTLS: number;
-    //#endregion
+  interface InitializationOptions {
+    /**
+     * NSS library parameters
+     */
+    libraryParameters?: string;
+    /**
+     * bit flags specifying options for {@link PKCS11.C_Initialize}
+     * - CKF_LIBRARY_CANT_CREATE_OS_THREADS. True if application threads which are executing calls to the library
+     *   may not use native operating system calls to spawn new threads; false if they may
+     * - CKF_OS_LOCKING_OK. True if the library can use the native operation system threading model for locking;
+     *   false otherwise
+     */
+    flags?: number;
+  }
 
-    //#region MGFs
-    const CKG_MGF1_SHA1: number;
-    const CKG_MGF1_SHA256: number;
-    const CKG_MGF1_SHA384: number;
-    const CKG_MGF1_SHA512: number;
-    const CKG_MGF1_SHA224: number;
-    //#endregion
-
-    //#region KDFs
-    const CKD_NULL: number;
-    const CKD_SHA1_KDF: number;
-    const CKD_SHA1_KDF_ASN1: number;
-    const CKD_SHA1_KDF_CONCATENATE: number;
-    const CKD_SHA224_KDF: number;
-    const CKD_SHA256_KDF: number;
-    const CKD_SHA384_KDF: number;
-    const CKD_SHA512_KDF: number;
-    const CKD_CPDIVERSIFY_KDF: number;
-    //#endregion
-
-    //#region Mech params
-    const CK_PARAMS_AES_CBC: number;
-    const CK_PARAMS_AES_CCM: number;
-    const CK_PARAMS_AES_GCM: number;
-    const CK_PARAMS_RSA_OAEP: number;
-    const CK_PARAMS_RSA_PSS: number;
-    const CK_PARAMS_EC_DH: number;
-    const CK_PARAMS_AES_GCM_v240: number;
-    const CK_PARAMS_ECDH2_DERIVE: number;
-    const CK_PARAMS_ECMQV_DERIVE: number;
-    const CK_PARAMS_X9_42_DH1_DERIVE: number;
-    const CK_PARAMS_X9_42_DH2_DERIVE: number;
-    const CK_PARAMS_X9_42_MQV_DERIVE: number;
-    const CK_PARAMS_KEA_DERIVE: number;
-    const CK_PARAMS_RC2: number;
-    const CK_PARAMS_RC2_CBC: number;
-    const CK_PARAMS_RC2_MAC_GENERAL: number;
-    const CK_PARAMS_RC5: number;
-    const CK_PARAMS_RC5_CBC: number;
-    const CK_PARAMS_RC5_MAC_GENERAL: number;
-    const CK_PARAMS_DES_CBC_ENCRYPT_DATA: number;
-    const CK_PARAMS_SKIPJACK_PRIVATE_WRAP: number;
-    const CK_PARAMS_SKIPJACK_RELAYX: number;
-    const CK_PARAMS_PBE: number;
-    const CK_PARAMS_KEY_WRAP_SET_OAEP: number;
-    const CK_PARAMS_GCM: number;
-    const CK_PARAMS_CCM: number;
-    const CK_PARAM_GOSTR3410_DERIVE: number;
-    const CK_PARAM_GOSTR3410_KEY_WRAP: number;
-    //#endregion
-
-    //#region User types
-    const CKU_SO: number;
-    const CKU_USER: number;
-    const CKU_CONTEXT_SPECIFIC: number;
-    //#endregion
-
-    // Initialize flags
-    const CKF_LIBRARY_CANT_CREATE_OS_THREADS: number;
-    const CKF_OS_LOCKING_OK: number;
-
-    //#region Result values
-    const CKR_OK: number;
-    const CKR_CANCEL: number;
-    const CKR_HOST_MEMORY: number;
-    const CKR_SLOT_ID_INVALID: number;
-    const CKR_GENERAL_ERROR: number;
-    const CKR_FUNCTION_FAILED: number;
-    const CKR_ARGUMENTS_BAD: number;
-    const CKR_NO_EVENT: number;
-    const CKR_NEED_TO_CREATE_THREADS: number;
-    const CKR_CANT_LOCK: number;
-    const CKR_ATTRIBUTE_READ_ONLY: number;
-    const CKR_ATTRIBUTE_SENSITIVE: number;
-    const CKR_ATTRIBUTE_TYPE_INVALID: number;
-    const CKR_ATTRIBUTE_VALUE_INVALID: number;
-    const CKR_DATA_INVALID: number;
-    const CKR_DATA_LEN_RANGE: number;
-    const CKR_DEVICE_ERROR: number;
-    const CKR_DEVICE_MEMORY: number;
-    const CKR_DEVICE_REMOVED: number;
-    const CKR_ENCRYPTED_DATA_INVALID: number;
-    const CKR_ENCRYPTED_DATA_LEN_RANGE: number;
-    const CKR_FUNCTION_CANCELED: number;
-    const CKR_FUNCTION_NOT_PARALLEL: number;
-    const CKR_FUNCTION_NOT_SUPPORTED: number;
-    const CKR_KEY_HANDLE_INVALID: number;
-    const CKR_KEY_SIZE_RANGE: number;
-    const CKR_KEY_TYPE_INCONSISTENT: number;
-    const CKR_KEY_NOT_NEEDED: number;
-    const CKR_KEY_CHANGED: number;
-    const CKR_KEY_NEEDED: number;
-    const CKR_KEY_INDIGESTIBLE: number;
-    const CKR_KEY_FUNCTION_NOT_PERMITTED: number;
-    const CKR_KEY_NOT_WRAPPABLE: number;
-    const CKR_KEY_UNEXTRACTABLE: number;
-    const CKR_MECHANISM_INVALID: number;
-    const CKR_MECHANISM_PARAM_INVALID: number;
-    const CKR_OBJECT_HANDLE_INVALID: number;
-    const CKR_OPERATION_ACTIVE: number;
-    const CKR_OPERATION_NOT_INITIALIZED: number;
-    const CKR_PIN_INCORRECT: number;
-    const CKR_PIN_INVALID: number;
-    const CKR_PIN_LEN_RANGE: number;
-    const CKR_PIN_EXPIRED: number;
-    const CKR_PIN_LOCKED: number;
-    const CKR_SESSION_CLOSED: number;
-    const CKR_SESSION_COUNT: number;
-    const CKR_SESSION_HANDLE_INVALID: number;
-    const CKR_SESSION_PARALLEL_NOT_SUPPORTED: number;
-    const CKR_SESSION_READ_ONLY: number;
-    const CKR_SESSION_EXISTS: number;
-    const CKR_SESSION_READ_ONLY_EXISTS: number;
-    const CKR_SESSION_READ_WRITE_SO_EXISTS: number;
-    const CKR_SIGNATURE_INVALID: number;
-    const CKR_SIGNATURE_LEN_RANGE: number;
-    const CKR_TEMPLATE_INCOMPLETE: number;
-    const CKR_TEMPLATE_INCONSISTENT: number;
-    const CKR_TOKEN_NOT_PRESENT: number;
-    const CKR_TOKEN_NOT_RECOGNIZED: number;
-    const CKR_TOKEN_WRITE_PROTECTED: number;
-    const CKR_UNWRAPPING_KEY_HANDLE_INVALID: number;
-    const CKR_UNWRAPPING_KEY_SIZE_RANGE: number;
-    const CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT: number;
-    const CKR_USER_ALREADY_LOGGED_IN: number;
-    const CKR_USER_NOT_LOGGED_IN: number;
-    const CKR_USER_PIN_NOT_INITIALIZED: number;
-    const CKR_USER_TYPE_INVALID: number;
-    const CKR_USER_ANOTHER_ALREADY_LOGGED_IN: number;
-    const CKR_USER_TOO_MANY_TYPES: number;
-    const CKR_WRAPPED_KEY_INVALID: number;
-    const CKR_WRAPPED_KEY_LEN_RANGE: number;
-    const CKR_WRAPPING_KEY_HANDLE_INVALID: number;
-    const CKR_WRAPPING_KEY_SIZE_RANGE: number;
-    const CKR_WRAPPING_KEY_TYPE_INCONSISTENT: number;
-    const CKR_RANDOM_SEED_NOT_SUPPORTED: number;
-    const CKR_RANDOM_NO_RNG: number;
-    const CKR_DOMAIN_PARAMS_INVALID: number;
-    const CKR_BUFFER_TOO_SMALL: number;
-    const CKR_SAVED_STATE_INVALID: number;
-    const CKR_INFORMATION_SENSITIVE: number;
-    const CKR_STATE_UNSAVEABLE: number;
-    const CKR_CRYPTOKI_NOT_INITIALIZED: number;
-    const CKR_CRYPTOKI_ALREADY_INITIALIZED: number;
-    const CKR_MUTEX_BAD: number;
-    const CKR_MUTEX_NOT_LOCKED: number;
-    const CKR_NEW_PIN_MODE: number;
-    const CKR_NEXT_OTP: number;
-    const CKR_EXCEEDED_MAX_ITERATIONS: number;
-    const CKR_FIPS_SELF_TEST_FAILED: number;
-    const CKR_LIBRARY_LOAD_FAILED: number;
-    const CKR_PIN_TOO_WEAK: number;
-    const CKR_PUBLIC_KEY_INVALID: number;
-    const CKR_FUNCTION_REJECTED: number;
-    //#endregion
+  /**
+   * A Structure which contains a Cryptoki version and each function in the Cryptoki API
+   */
+  export class PKCS11 {
+    /**
+     * Library path
+     */
+    public libPath: string;
 
     /**
-     * Exception from native module
+     * Creates an instance of PKCS11
+     * @param libPath The path to PKCS#11 library
      */
-    class NativeError extends Error {
-        /**
-         * Native library call stack. Default is empty string
-         */
-        public readonly nativeStack: string;
-        /**
-         * Native function name. Default is empty string
-         */
-        public readonly method: string;
-        /**
-         * Initialize new instance of NativeError
-         * @param message Error message
-         */
-        public constructor(message?: string, method?: string);
-    }
+    constructor(libPath?: string);
 
     /**
-     * Exception with the name and value of PKCS#11 return value
+     * Loads dynamic library with PKCS#11 interface
+     * @param path The path to PKCS#11 library
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
      */
-    class Pkcs11Error extends NativeError {
-        /**
-         * PKCS#11 result value. Default is 0
-         */
-        public readonly code: number;
-        /**
-         * Initialize new instance of Pkcs11Error
-         * @param message Error message
-         * @param code PKCS#11 result value
-         * @param method The name of PKCS#11 method
-         */
-        public constructor(message?: string, code?: number, method?: string);
-    }
+    public load(path: string): void;
+    /**
+     * Initializes the Cryptoki library
+     * @param options Initialization options
+     * Supports implementation of standard `CK_C_INITIALIZE_ARGS` and extended NSS format.
+     * - if `options` is null or empty, it calls native `C_Initialize` with `NULL`
+     * - if `options` doesn't have `libraryParameters`, it uses `CK_C_INITIALIZE_ARGS` structure
+     * - if `options` has `libraryParameters`, it uses extended NSS structure
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Initialize(options?: InitializationOptions): void;
+    /**
+     * Closes dynamic library
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public close(): void;
+    /**
+     * Indicates that an application is done with the Cryptoki library
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Finalize(): void;
+    /**
+     * Returns general information about Cryptoki
+     * @returns Information about Cryptoki
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetInfo(): ModuleInfo;
+
+    //#region Slot and token management
+
+    /**
+     * Obtains a list of slots in the system
+     * @param [tokenPresent] Only slots with tokens?
+     * @returns Array of slot IDs
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetSlotList(tokenPresent?: boolean): Handle[];
+    /**
+     * Obtains information about a particular slot in the system
+     * @param  slot The ID of the slot
+     * @returns Information about a slot
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetSlotInfo(slot: Handle): SlotInfo;
+    /**
+     * Obtains information about a particular token in the system
+     * @param slot ID of the token's slot
+     * @returns Information about a token
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetTokenInfo(slot: Handle): TokenInfo;
+    /**
+     * Initializes a token
+     * @param slot ID of the token's slot
+     * @param [pin] The SO's initial PIN
+     * @returns 32-byte token label (blank padded)
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_InitToken(slot: Handle, pin?: string, label?: string): string;
+    /**
+     * Initializes the normal user's PIN
+     * @param session The session's handle
+     * @param pin The normal user's PIN
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_InitPIN(session: Handle, pin?: string): void;
+    /**
+     * Modifies the PIN of the user who is logged in
+     * @param session The session's handle
+     * @param oldPin The old PIN
+     * @param newPin The new PIN
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SetPIN(session: Handle, oldPin: string, newPin: string): void;
+    /**
+     * Obtains a list of mechanism types supported by a token
+     * @param slot ID of token's slot
+     * @returns A list of mechanism types
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetMechanismList(slot: Handle): number[];
+    /**
+     * Obtains information about a particular mechanism possibly supported by a token
+     * @param slot ID of the token's slot
+     * @param mech Type of mechanism
+     * @returns Information about mechanism
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetMechanismInfo(slot: Handle, mech: number): MechanismInfo;
+
+    //#endregion
+
+    //#region Session management
+
+    /**
+     * Opens a session between an application and a token
+     * @param slot The slot's ID
+     * @param flags From CK_SESSION_INFO
+     * @returns Session handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_OpenSession(slot: Handle, flags: number): Handle;
+    /**
+     * Closes a session between an application and a token
+     * @param session The session's handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_CloseSession(session: Handle): void;
+    /**
+     * Closes all sessions with a token
+     * @param slot The token's slot
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_CloseAllSessions(slot: Handle): void;
+    /**
+     * Obtains information about the session
+     * @param session The session's handle
+     * @returns Receives session info
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetSessionInfo(session: Handle): SessionInfo;
+    /**
+     * Logs a user into a token
+     * @param session The session's handle
+     * @param userType The user type
+     * @param [pin] The user's PIN
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Login(session: Handle, userType: number, pin?: string): void;
+    /**
+     * Logs a user out from a token
+     * @param session The session's handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Logout(session: Handle): void;
+
+    //#endregion
+
+    //#region Object management
+
+    /**
+     * Creates a new object
+     * @param session The session's handle
+     * @param template The object's template
+     * @returns A new object's handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_CreateObject(session: Handle, template: Template): Handle;
+    /**
+     * Copies an object, creating a new object for the copy
+     * @param session The session's handle
+     * @param object The object's handle
+     * @param template Template for new object
+     * @returns A handle of copy
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_CopyObject(
+      session: Handle,
+      object: Handle,
+      template: Template
+    ): Handle;
+    /**
+     * Destroys an object
+     * @param session The session's handle
+     * @param object The object's handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DestroyObject(session: Handle, object: Handle): void;
+    /**
+     * Gets the size of an object in bytes
+     * @param session The session's handle
+     * @param object The object's handle
+     * @returns Size of an object in bytes
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetObjectSize(session: Handle, object: Handle): number;
+    /**
+     * Initializes a search for token and session objects that match a template
+     * @param session The session's handle
+     * @param template Attribute values to match
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_FindObjectsInit(session: Handle, template: Template): void;
+    /**
+     * Continues a search for token and session
+     * objects that match a template, obtaining additional object
+     * handles
+     * @param session The session's handle
+     * @param maxObjectCount The maximum number of object handles to be returned. Default value is 1.
+     * @returns List of handles
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_FindObjects(session: Handle, maxObjectCount: number): Handle[];
+    /**
+     * Continues a search for token and session
+     * objects that match a template, obtaining additional object
+     * handles
+     * @param session The session's handle
+     * @returns Object's handle. If object is not found
+     * the result is null
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_FindObjects(session: Handle): Handle | null;
+    /**
+     * Finishes a search for token and session objects
+     * @param session The session's handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_FindObjectsFinal(session: Handle): void;
+    /**
+     * Obtains the value of one or more object attributes
+     * @param session The session's handle
+     * @param object The object's handle
+     * @param template Specifies attrs; gets values
+     * @returns List of Attributes with values
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GetAttributeValue(
+      session: Handle,
+      object: Handle,
+      template: Template
+    ): TemplateResult;
+    /**
+     * Modifies the value of one or more object attributes
+     * @param session The session's handle
+     * @param object The object's handle
+     * @param template Specifies attrs and values
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SetAttributeValue(
+      session: Handle,
+      object: Handle,
+      template: Template
+    ): void;
+
+    //#endregion
+
+    //#region Encryption and decryption
+
+    /**
+     * Initializes an encryption operation
+     * @param session The session's handle
+     * @param mechanism The encryption mechanism
+     * @param key Handle of encryption key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_EncryptInit(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle
+    ): void;
+    /**
+     * Encrypts single-part data
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data with encrypted message
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Encrypt(session: Handle, inData: Buffer, outData: Buffer): Buffer;
+    /**
+     * Encrypts single-part data
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Encrypt(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Encrypts single-part data
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data with encrypted message
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_EncryptAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Continues a multiple-part encryption operation
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_EncryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Finishes a multiple-part encryption operation
+     * @param session The session's handle
+     * @param outData Last output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_EncryptFinal(session: Handle, outData: Buffer): Buffer;
+    /**
+     * Finishes a multiple-part encryption operation
+     * @param session The session's handle
+     * @param outData Last output data
+     * @param cb Async callback with sliced output data
+     */
+    public C_EncryptFinal(
+      session: Handle,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Finishes a multiple-part encryption operation
+     * @param session The session's handle
+     * @param outData Last output data
+     * @returns Sliced output data
+     */
+    public C_EncryptFinalAsync(
+      session: Handle,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Initializes a decryption operation
+     * @param session The session's handle
+     * @param mechanism The decryption mechanism
+     * @param key Handle of decryption key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DecryptInit(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle
+    ): void;
+    /**
+     * Decrypts encrypted data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data with decrypted message
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Decrypt(session: Handle, inData: Buffer, outData: Buffer): Buffer;
+    /**
+     * Decrypts encrypted data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Decrypt(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Decrypts encrypted data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data with decrypted message
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DecryptAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * continues a multiple-part decryption operation
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data with decrypted block
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DecryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Finishes a multiple-part decryption operation
+     * @param session The session's handle
+     * @param outData Last part of output data
+     * @returns Sliced output data with decrypted final block
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DecryptFinal(session: Handle, outData: Buffer): Buffer;
+    /**
+     * Finishes a multiple-part decryption operation
+     * @param session The session's handle
+     * @param outData Last part of output data
+     * @param cb Async callback with sliced output data with decrypted final block
+     */
+    public C_DecryptFinal(
+      session: Handle,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Finishes a multiple-part decryption operation
+     * @param session The session's handle
+     * @param outData Last part of output data
+     * @returns Sliced output data with decrypted final block
+     */
+    public C_DecryptFinalAsync(
+      session: Handle,
+      outData: Buffer
+    ): Promise<Buffer>;
+
+    /* Message digesting */
+
+    /**
+     * Initializes a message-digesting operation
+     * @param session The session's handle
+     * @param mechanism Digesting mechanism
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestInit(session: Handle, mechanism: Mechanism): void;
+    /**
+     * Digests data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Digest(session: Handle, inData: Buffer, outData: Buffer): Buffer;
+    /**
+     * Digests data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Digest(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Digests data in a single part
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * continues a multiple-part message-digesting operation
+     * operation, by digesting the value of a secret key as part of
+     * the data already digested
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestUpdate(session: Handle, inData: Buffer): void;
+    /**
+     * Finishes a multiple-part message-digesting operation
+     * @param session The session's handle
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestFinal(session: Handle, outData: Buffer): Buffer;
+    /**
+     * Finishes a multiple-part message-digesting operation
+     * @param session The session's handle
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     */
+    public C_DigestFinal(
+      session: Handle,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Finishes a multiple-part message-digesting operation
+     * @param session The session's handle
+     * @param outData Output data
+     * @returns Sliced output data
+     */
+    public C_DigestFinalAsync(
+      session: Handle,
+      outData: Buffer
+    ): Promise<Buffer>;
+
+    /**
+     * Continues a multiple-part message-digesting operation by digesting the value of a secret key
+     * @param session The session's handle
+     * @param key The handle of the secret key to be digested
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestKey(session: Handle, key: Handle): void;
+
+    //#endregion
+
+    //#region Signing and MACing
+
+    /**
+     * initializes a signature (private key encryption)
+     * operation, where the signature is (will be) an appendix to
+     * the data, and plaintext cannot be recovered from the
+     * signature
+     * @param session The session's handle
+     * @param mechanism Signature mechanism
+     * @param key Handle of signature key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignInit(session: Handle, mechanism: Mechanism, key: Handle): void;
+    /**
+     * Signs (encrypts with private key) data in a single
+     * part, where the signature is (will be) an appendix to the
+     * data, and plaintext cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Sign(session: Handle, inData: Buffer, outData: Buffer): Buffer;
+    /**
+     * Signs (encrypts with private key) data in a single
+     * part, where the signature is (will be) an appendix to the
+     * data, and plaintext cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Sign(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Signs (encrypts with private key) data in a single
+     * part, where the signature is (will be) an appendix to the
+     * data, and plaintext cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Continues a multiple-part signature operation,
+     * where the signature is (will be) an appendix to the data,
+     * and plaintext cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignUpdate(session: Handle, inData: Buffer): void;
+    /**
+     * Finishes a multiple-part signature operation,
+     * returning the signature
+     * @param session The session's handle
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignFinal(session: Handle, outData: Buffer): Buffer;
+    /**
+     * Finishes a multiple-part signature operation,
+     * returning the signature
+     * @param session The session's handle
+     * @param outData Output data
+     * @param cb Async callback with sliced output data
+     */
+    public C_SignFinal(
+      session: Handle,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Finishes a multiple-part signature operation,
+     * returning the signature
+     * @param session The session's handle
+     * @param outData Output data
+     * @returns Sliced output data
+     */
+    public C_SignFinalAsync(session: Handle, outData: Buffer): Promise<Buffer>;
+
+    /**
+     * Initializes a signature operation, where the data can be recovered from the signature
+     * @param session The session's handle
+     * @param mechanism The structure that specifies the signature mechanism
+     * @param key The handle of the signature key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignRecoverInit(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle
+    ): void;
+    /**
+     * Signs data in a single operation, where the data can be recovered from the signature
+     * @param session
+     * @param inData Incoming data
+     * @param outData Output data
+     * @returns Sliced output data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignRecover(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+
+    //#endregion
+
+    //#region Verifying signatures and MACs
+
+    /**
+     * initializes a verification operation, where the
+     * signature is an appendix to the data, and plaintext cannot
+     * cannot be recovered from the signature (e.g. DSA)
+     * @param session The session's handle
+     * @param mechanism Verification mechanism
+     * @param key Verification key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_VerifyInit(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle
+    ): void;
+    /**
+     * Verifies a signature in a single-part operation,
+     * where the signature is an appendix to the data, and plaintext
+     * cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param signature Signature to verify
+     * @returns Verification result
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Verify(
+      session: Handle,
+      inData: Buffer,
+      signature: Buffer
+    ): boolean;
+    /**
+     * Verifies a signature in a single-part operation,
+     * where the signature is an appendix to the data, and plaintext
+     * cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param signature Signature to verify
+     * @param cb Async callback with verification result
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_Verify(
+      session: Handle,
+      inData: Buffer,
+      signature: Buffer,
+      cb: (error: Error, verify: boolean) => void
+    ): void;
+    /**
+     * Verifies a signature in a single-part operation,
+     * where the signature is an appendix to the data, and plaintext
+     * cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @param signature Signature to verify
+     * @returns Verification result
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_VerifyAsync(
+      session: Handle,
+      inData: Buffer,
+      signature: Buffer
+    ): Promise<boolean>;
+    /**
+     * Continues a multiple-part verification
+     * operation, where the signature is an appendix to the data,
+     * and plaintext cannot be recovered from the signature
+     * @param session The session's handle
+     * @param inData Incoming data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_VerifyUpdate(session: Handle, inData: Buffer): void;
+    /**
+     * Finishes a multiple-part verification
+     * operation, checking the signature
+     * @param session The session's handle
+     * @param signature Signature to verify
+     * @returns
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_VerifyFinal(session: Handle, signature: Buffer): boolean;
+    /**
+     * Finishes a multiple-part verification
+     * operation, checking the signature
+     * @param session The session's handle
+     * @param signature Signature to verify
+     * @param cb Async callback with verification result
+     */
+    public C_VerifyFinal(
+      session: Handle,
+      signature: Buffer,
+      cb: (error: Error, verify: boolean) => void
+    ): void;
+    /**
+     * Finishes a multiple-part verification
+     * operation, checking the signature
+     * @param session The session's handle
+     * @param signature Signature to verify
+     * @returns Verification result
+     */
+    public C_VerifyFinalAsync(
+      session: Handle,
+      signature: Buffer
+    ): Promise<boolean>;
+    /**
+     * Initializes a signature verification operation, where the data is recovered from the signature
+     * @param session The session's handle
+     * @param mechanism The structure that specifies the verification mechanism
+     * @param key The handle of the verification key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    C_VerifyRecoverInit(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle
+    ): void;
+    /**
+     * Verifies a signature in a single-part operation, where the data is recovered from the signature
+     * @param session The session's handle
+     * @param signature The signature to verify
+     * @param outData The allocated buffer for recovered data
+     * @return The sliced output data with recovered data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    C_VerifyRecover(
+      session: Handle,
+      signature: Buffer,
+      outData: Buffer
+    ): Buffer;
+
+    //#endregion
+
+    //#region Key management
+
+    /**
+     * Generates a secret key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism Key generation mechanism
+     * @param template Template for new key
+     * @returns The handle of the new key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKey(
+      session: Handle,
+      mechanism: Mechanism,
+      template: Template
+    ): Handle;
+    /**
+     * Generates a secret key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism Key generation mechanism
+     * @param template Template for new key
+     * @param cb Async callback with handle of new key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKey(
+      session: Handle,
+      mechanism: Mechanism,
+      template: Template,
+      cb: (error: Error, key: Handle) => void
+    ): void;
+    /**
+     * Generates a secret key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism The key generation mechanism
+     * @param template The template for the new key
+     * @returns The handle of the new key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKeyAsync(
+      session: Handle,
+      mechanism: Mechanism,
+      template: Template
+    ): Promise<Handle>;
+    /**
+     * Generates a public-key/private-key pair,
+     * creating new key objects
+     * @param session The session's handle
+     * @param mechanism Key generation mechanism
+     * @param publicTmpl Template for public key
+     * @param privateTmpl Template for private key
+     * @returns The pair of handles for private and public keys
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKeyPair(
+      session: Handle,
+      mechanism: Mechanism,
+      publicTmpl: Template,
+      privateTmpl: Template
+    ): KeyPair;
+    /**
+     * Generates a public-key/private-key pair,
+     * creating new key objects
+     * @param session The session's handle
+     * @param mechanism Key generation mechanism
+     * @param publicTmpl Template for public key
+     * @param privateTmpl Template for private key
+     * @param cb Async callback with handles for private and public keys
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKeyPair(
+      session: Handle,
+      mechanism: Mechanism,
+      publicTmpl: Template,
+      privateTmpl: Template,
+      cb: (error: Error, keys: KeyPair) => void
+    ): void;
+    /**
+     * Generates a public-key/private-key pair,
+     * creating new key objects
+     * @param session The session's handle
+     * @param mechanism Key generation mechanism
+     * @param publicTmpl Template for public key
+     * @param privateTmpl Template for private key
+     * @returns Handles for private and public keys
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateKeyPairAsync(
+      session: Handle,
+      mechanism: Mechanism,
+      publicTmpl: Template,
+      privateTmpl: Template
+    ): Promise<KeyPair>;
+    /**
+     * Wraps (i.e., encrypts) a key
+     * @param session The session's handle
+     * @param mechanism Wrapping mechanism
+     * @param wrappingKey Wrapping key
+     * @param key Key to be wrapped
+     * @param wrappedKey Init buffer for wrapped key
+     * @returns Sliced wrapped key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_WrapKey(
+      session: Handle,
+      mechanism: Mechanism,
+      wrappingKey: Handle,
+      key: Handle,
+      wrappedKey: Buffer
+    ): Buffer;
+    /**
+     * Wraps (i.e., encrypts) a key
+     * @param session The session's handle
+     * @param mechanism Wrapping mechanism
+     * @param wrappingKey Wrapping key
+     * @param key Key to be wrapped
+     * @param wrappedKey Init buffer for wrapped key
+     * @param cb Async callback with sliced wrapped key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_WrapKey(
+      session: Handle,
+      mechanism: Mechanism,
+      wrappingKey: Handle,
+      key: Handle,
+      wrappedKey: Buffer,
+      cb: (error: Error, wrappedKey: Buffer) => void
+    ): void;
+    /**
+     * Wraps (i.e., encrypts) a key
+     * @param session The session's handle
+     * @param mechanism Wrapping mechanism
+     * @param wrappingKey Wrapping key
+     * @param key Key to be wrapped
+     * @param wrappedKey Init buffer for wrapped key
+     * @returns Sliced wrapped key
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_WrapKeyAsync(
+      session: Handle,
+      mechanism: Mechanism,
+      wrappingKey: Handle,
+      key: Handle,
+      wrappedKey: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism Unwrapping mechanism
+     * @param unwrappingKey Unwrapping key
+     * @param wrappedKey Wrapped key
+     * @param template New key template
+     * @returns The unwrapped key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_UnwrapKey(
+      session: Handle,
+      mechanism: Mechanism,
+      unwrappingKey: Handle,
+      wrappedKey: Buffer,
+      template: Template
+    ): Handle;
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism Unwrapping mechanism
+     * @param unwrappingKey Unwrapping key
+     * @param wrappedKey Wrapped key
+     * @param template New key template
+     * @param cb Async callback with new key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_UnwrapKey(
+      session: Handle,
+      mechanism: Mechanism,
+      unwrappingKey: Handle,
+      wrappedKey: Buffer,
+      template: Template,
+      cb: (error: Error, key: Handle) => void
+    ): void;
+    /**
+     * Unwraps (decrypts) a wrapped key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism Unwrapping mechanism
+     * @param unwrappingKey Unwrapping key
+     * @param wrappedKey Wrapped key
+     * @param template New key template
+     * @returns The unwrapped key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_UnwrapKeyAsync(
+      session: Handle,
+      mechanism: Mechanism,
+      unwrappingKey: Handle,
+      wrappedKey: Buffer,
+      template: Template
+    ): Promise<Handle>;
+    /**
+     * Derives a key from a base key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism The key derivation mechanism
+     * @param key The base key
+     * @param template The template for the new key
+     * @returns The derived key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DeriveKey(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle,
+      template: Template
+    ): Handle;
+    /**
+     * Derives a key from a base key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism The key derivation mechanism
+     * @param key The base key
+     * @param template The template for the new key
+     * @param cb Async callback with the derived key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DeriveKey(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle,
+      template: Template,
+      cb: (error: Error, hKey: Handle) => void
+    ): void;
+    /**
+     * Derives a key from a base key, creating a new key object
+     * @param session The session's handle
+     * @param mechanism The key derivation mechanism
+     * @param key The base key
+     * @param template The template for the new key
+     * @returns The derived key handle
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DeriveKeyAsync(
+      session: Handle,
+      mechanism: Mechanism,
+      key: Handle,
+      template: Template
+    ): Promise<Handle>;
+    /**
+     * Mixes additional seed material into the token's random number generator
+     * @param session The session's handle
+     * @param buf The seed material
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SeedRandom(session: Handle, buf: Buffer): void;
+    /**
+     * Generates random data
+     * @param session The session's handle
+     * @param buf Init buffer
+     * @returns The random data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_GenerateRandom(session: Handle, buf: Buffer): Buffer;
+    //#endregion
+
+    //#region Event management
+    /**
+     * Waits for a slot event, such as token insertion or token removal, to occur.
+     * @param flags Determines whether or not the C_WaitForSlotEvent call blocks (i.e., waits for a slot event to occur); use CKF_DONT_BLOCK for no blocking call
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     * @returns The slot ID where the event occurred, if successful; null otherwise
+     */
+    public C_WaitForSlotEvent(flags: number): Handle | null;
+    //#endregion
+
+    //#region Dual-function cryptographic operations
+    /**
+     * Continues a multiple-part digest and encryption
+     * operation (digesting and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be digested and encrypted
+     * @param outData Encrypted data
+     * @returns Sliced encrypted data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_DigestEncryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Continues a multiple-part digest and encryption
+     * operation (digesting and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be digested and encrypted
+     * @param outData Encrypted data
+     * @param cb Async callback with sliced encrypted data
+     */
+    public C_DigestEncryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Continues a multiple-part digest and encryption
+     * operation (digesting and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be digested and encrypted
+     * @param outData Encrypted data
+     * @returns Sliced encrypted data
+     */
+    public C_DigestEncryptUpdateAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Continues a multiple-part decryption and digest
+     * operation (decrypting and digesting)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and digested
+     * @param outData Digested data
+     * @returns Sliced digested data
+     */
+    public C_DecryptDigestUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Continues a multiple-part decryption and digest
+     * operation (decrypting and digesting)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and digested
+     * @param outData Digested data
+     * @param cb Async callback with sliced digested data
+     */
+    public C_DecryptDigestUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Continues a multiple-part decryption and digest
+     * operation (decrypting and digesting)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and digested
+     * @param outData Digested data
+     * @returns Sliced digested data
+     */
+    public C_DecryptDigestUpdateAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Continues a multiple-part signing and encryption
+     * operation (signing and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be signed and encrypted
+     * @param outData Encrypted data
+     * @returns Sliced encrypted data
+     * @throws {@link NativeError} if native error occurs
+     * @throws {@link Pkcs11Error} if Cryptoki error occurs
+     */
+    public C_SignEncryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Continues a multiple-part signing and encryption
+     * operation (signing and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be signed and encrypted
+     * @param outData Encrypted data
+     * @param cb Async callback with sliced encrypted data
+     */
+    public C_SignEncryptUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Continues a multiple-part signing and encryption
+     * operation (signing and encrypting)
+     * @param session The session's handle
+     * @param inData Data to be signed and encrypted
+     * @param outData Encrypted data
+     * @returns Sliced encrypted data
+     */
+    public C_SignEncryptUpdateAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    /**
+     * Continues a multiple-part decryption and
+     * verification operation (decrypting and verifying)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and verified
+     * @param outData Verified data
+     * @returns Sliced verified data
+     */
+    public C_DecryptVerifyUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Buffer;
+    /**
+     * Continues a multiple-part decryption and
+     * verification operation (decrypting and verifying)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and verified
+     * @param outData Verified data
+     * @param cb Async callback with sliced verified data
+     */
+    public C_DecryptVerifyUpdate(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer,
+      cb: (error: Error, data: Buffer) => void
+    ): void;
+    /**
+     * Continues a multiple-part decryption and
+     * verification operation (decrypting and verifying)
+     * @param session The session's handle
+     * @param inData Data to be decrypted and verified
+     * @param outData Verified data
+     * @returns Sliced verified data
+     */
+    public C_DecryptVerifyUpdateAsync(
+      session: Handle,
+      inData: Buffer,
+      outData: Buffer
+    ): Promise<Buffer>;
+    //#endregion
+  }
+
+  //#region Attributes
+  const CKA_CLASS: number;
+  const CKA_TOKEN: number;
+  const CKA_PRIVATE: number;
+  const CKA_LABEL: number;
+  const CKA_APPLICATION: number;
+  const CKA_VALUE: number;
+  const CKA_OBJECT_ID: number;
+  const CKA_CERTIFICATE_TYPE: number;
+  const CKA_ISSUER: number;
+  const CKA_SERIAL_NUMBER: number;
+  const CKA_AC_ISSUER: number;
+  const CKA_OWNER: number;
+  const CKA_ATTR_TYPES: number;
+  const CKA_TRUSTED: number;
+  const CKA_CERTIFICATE_CATEGORY: number;
+  const CKA_JAVA_MIDP_SECURITY_DOMAIN: number;
+  const CKA_URL: number;
+  const CKA_HASH_OF_SUBJECT_PUBLIC_KEY: number;
+  const CKA_HASH_OF_ISSUER_PUBLIC_KEY: number;
+  const CKA_NAME_HASH_ALGORITHM: number;
+  const CKA_CHECK_VALUE: number;
+  const CKA_KEY_TYPE: number;
+  const CKA_SUBJECT: number;
+  const CKA_ID: number;
+  const CKA_SENSITIVE: number;
+  const CKA_ENCRYPT: number;
+  const CKA_DECRYPT: number;
+  const CKA_WRAP: number;
+  const CKA_UNWRAP: number;
+  const CKA_SIGN: number;
+  const CKA_SIGN_RECOVER: number;
+  const CKA_VERIFY: number;
+  const CKA_VERIFY_RECOVER: number;
+  const CKA_DERIVE: number;
+  const CKA_START_DATE: number;
+  const CKA_END_DATE: number;
+  const CKA_MODULUS: number;
+  const CKA_MODULUS_BITS: number;
+  const CKA_PUBLIC_EXPONENT: number;
+  const CKA_PRIVATE_EXPONENT: number;
+  const CKA_PRIME_1: number;
+  const CKA_PRIME_2: number;
+  const CKA_EXPONENT_1: number;
+  const CKA_EXPONENT_2: number;
+  const CKA_COEFFICIENT: number;
+  const CKA_PRIME: number;
+  const CKA_SUBPRIME: number;
+  const CKA_BASE: number;
+  const CKA_PRIME_BITS: number;
+  const CKA_SUBPRIME_BITS: number;
+  const CKA_SUB_PRIME_BITS: number;
+  const CKA_VALUE_BITS: number;
+  const CKA_VALUE_LEN: number;
+  const CKA_EXTRACTABLE: number;
+  const CKA_LOCAL: number;
+  const CKA_NEVER_EXTRACTABLE: number;
+  const CKA_ALWAYS_SENSITIVE: number;
+  const CKA_KEY_GEN_MECHANISM: number;
+  const CKA_MODIFIABLE: number;
+  const CKA_COPYABLE: number;
+  const CKA_DESTROYABLE: number;
+  const CKA_ECDSA_PARAMS: number;
+  const CKA_EC_PARAMS: number;
+  const CKA_EC_POINT: number;
+  const CKA_SECONDARY_AUTH: number;
+  const CKA_AUTH_PIN_FLAGS: number;
+  const CKA_ALWAYS_AUTHENTICATE: number;
+  const CKA_WRAP_WITH_TRUSTED: number;
+  const CKA_WRAP_TEMPLATE: number;
+  const CKA_UNWRAP_TEMPLATE: number;
+  const CKA_DERIVE_TEMPLATE: number;
+  const CKA_OTP_FORMAT: number;
+  const CKA_OTP_LENGTH: number;
+  const CKA_OTP_TIME_INTERVAL: number;
+  const CKA_OTP_USER_FRIENDLY_MODE: number;
+  const CKA_OTP_CHALLENGE_REQUIREMENT: number;
+  const CKA_OTP_TIME_REQUIREMENT: number;
+  const CKA_OTP_COUNTER_REQUIREMENT: number;
+  const CKA_OTP_PIN_REQUIREMENT: number;
+  const CKA_OTP_COUNTER: number;
+  const CKA_OTP_TIME: number;
+  const CKA_OTP_USER_IDENTIFIER: number;
+  const CKA_OTP_SERVICE_IDENTIFIER: number;
+  const CKA_OTP_SERVICE_LOGO: number;
+  const CKA_OTP_SERVICE_LOGO_TYPE: number;
+  const CKA_GOSTR3410_PARAMS: number;
+  const CKA_GOSTR3411_PARAMS: number;
+  const CKA_GOST28147_PARAMS: number;
+  const CKA_HW_FEATURE_TYPE: number;
+  const CKA_RESET_ON_INIT: number;
+  const CKA_HAS_RESET: number;
+  const CKA_PIXEL_X: number;
+  const CKA_PIXEL_Y: number;
+  const CKA_RESOLUTION: number;
+  const CKA_CHAR_ROWS: number;
+  const CKA_CHAR_COLUMNS: number;
+  const CKA_COLOR: number;
+  const CKA_BITS_PER_PIXEL: number;
+  const CKA_CHAR_SETS: number;
+  const CKA_ENCODING_METHODS: number;
+  const CKA_MIME_TYPES: number;
+  const CKA_MECHANISM_TYPE: number;
+  const CKA_REQUIRED_CMS_ATTRIBUTES: number;
+  const CKA_DEFAULT_CMS_ATTRIBUTES: number;
+  const CKA_SUPPORTED_CMS_ATTRIBUTES: number;
+  const CKA_ALLOWED_MECHANISMS: number;
+  const CKA_VENDOR_DEFINED: number;
+  //#endregion
+
+  //#region Objects
+  const CKO_DATA: number;
+  const CKO_CERTIFICATE: number;
+  const CKO_PUBLIC_KEY: number;
+  const CKO_PRIVATE_KEY: number;
+  const CKO_SECRET_KEY: number;
+  const CKO_HW_FEATURE: number;
+  const CKO_DOMAIN_PARAMETERS: number;
+  const CKO_MECHANISM: number;
+  const CKO_OTP_KEY: number;
+  const CKO_VENDOR_DEFINED: number;
+  //#endregion
+
+  //#region Key types
+  const CKK_RSA: number;
+  const CKK_DSA: number;
+  const CKK_DH: number;
+  const CKK_ECDSA: number;
+  const CKK_EC: number;
+  const CKK_X9_42_DH: number;
+  const CKK_KEA: number;
+  const CKK_GENERIC_SECRET: number;
+  const CKK_RC2: number;
+  const CKK_RC4: number;
+  const CKK_DES: number;
+  const CKK_DES2: number;
+  const CKK_DES3: number;
+  const CKK_CAST: number;
+  const CKK_CAST3: number;
+  const CKK_CAST5: number;
+  const CKK_CAST128: number;
+  const CKK_RC5: number;
+  const CKK_IDEA: number;
+  const CKK_SKIPJACK: number;
+  const CKK_BATON: number;
+  const CKK_JUNIPER: number;
+  const CKK_CDMF: number;
+  const CKK_AES: number;
+  const CKK_BLOWFISH: number;
+  const CKK_TWOFISH: number;
+  const CKK_SECURID: number;
+  const CKK_HOTP: number;
+  const CKK_ACTI: number;
+  const CKK_CAMELLIA: number;
+  const CKK_ARIA: number;
+  const CKK_MD5_HMAC: number;
+  const CKK_SHA_1_HMAC: number;
+  const CKK_RIPEMD128_HMAC: number;
+  const CKK_RIPEMD160_HMAC: number;
+  const CKK_SHA256_HMAC: number;
+  const CKK_SHA384_HMAC: number;
+  const CKK_SHA512_HMAC: number;
+  const CKK_SHA224_HMAC: number;
+  const CKK_SEED: number;
+  const CKK_GOSTR3410: number;
+  const CKK_GOSTR3411: number;
+  const CKK_GOST28147: number;
+  const CKK_VENDOR_DEFINED: number;
+  //#endregion
+
+  //#region Mechanisms
+  const CKM_RSA_PKCS_KEY_PAIR_GEN: number;
+  const CKM_RSA_PKCS: number;
+  const CKM_RSA_9796: number;
+  const CKM_RSA_X_509: number;
+  const CKM_MD2_RSA_PKCS: number;
+  const CKM_MD5_RSA_PKCS: number;
+  const CKM_SHA1_RSA_PKCS: number;
+  const CKM_RIPEMD128_RSA_PKCS: number;
+  const CKM_RIPEMD160_RSA_PKCS: number;
+  const CKM_RSA_PKCS_OAEP: number;
+  const CKM_RSA_X9_31_KEY_PAIR_GEN: number;
+  const CKM_RSA_X9_31: number;
+  const CKM_SHA1_RSA_X9_31: number;
+  const CKM_RSA_PKCS_PSS: number;
+  const CKM_SHA1_RSA_PKCS_PSS: number;
+  const CKM_DSA_KEY_PAIR_GEN: number;
+  const CKM_DSA: number;
+  const CKM_DSA_SHA1: number;
+  const CKM_DSA_SHA224: number;
+  const CKM_DSA_SHA256: number;
+  const CKM_DSA_SHA384: number;
+  const CKM_DSA_SHA512: number;
+  const CKM_DH_PKCS_KEY_PAIR_GEN: number;
+  const CKM_DH_PKCS_DERIVE: number;
+  const CKM_X9_42_DH_KEY_PAIR_GEN: number;
+  const CKM_X9_42_DH_DERIVE: number;
+  const CKM_X9_42_DH_HYBRID_DERIVE: number;
+  const CKM_X9_42_MQV_DERIVE: number;
+  const CKM_SHA256_RSA_PKCS: number;
+  const CKM_SHA384_RSA_PKCS: number;
+  const CKM_SHA512_RSA_PKCS: number;
+  const CKM_SHA256_RSA_PKCS_PSS: number;
+  const CKM_SHA384_RSA_PKCS_PSS: number;
+  const CKM_SHA512_RSA_PKCS_PSS: number;
+  const CKM_SHA224_RSA_PKCS: number;
+  const CKM_SHA224_RSA_PKCS_PSS: number;
+  const CKM_RC2_KEY_GEN: number;
+  const CKM_RC2_ECB: number;
+  const CKM_RC2_CBC: number;
+  const CKM_RC2_MAC: number;
+  const CKM_RC2_MAC_GENERAL: number;
+  const CKM_RC2_CBC_PAD: number;
+  const CKM_RC4_KEY_GEN: number;
+  const CKM_RC4: number;
+  const CKM_DES_KEY_GEN: number;
+  const CKM_DES_ECB: number;
+  const CKM_DES_CBC: number;
+  const CKM_DES_MAC: number;
+  const CKM_DES_MAC_GENERAL: number;
+  const CKM_DES_CBC_PAD: number;
+  const CKM_DES2_KEY_GEN: number;
+  const CKM_DES3_KEY_GEN: number;
+  const CKM_DES3_ECB: number;
+  const CKM_DES3_CBC: number;
+  const CKM_DES3_MAC: number;
+  const CKM_DES3_MAC_GENERAL: number;
+  const CKM_DES3_CBC_PAD: number;
+  const CKM_DES3_CMAC_GENERAL: number;
+  const CKM_DES3_CMAC: number;
+  const CKM_CDMF_KEY_GEN: number;
+  const CKM_CDMF_ECB: number;
+  const CKM_CDMF_CBC: number;
+  const CKM_CDMF_MAC: number;
+  const CKM_CDMF_MAC_GENERAL: number;
+  const CKM_CDMF_CBC_PAD: number;
+  const CKM_DES_OFB64: number;
+  const CKM_DES_OFB8: number;
+  const CKM_DES_CFB64: number;
+  const CKM_DES_CFB8: number;
+  const CKM_MD2: number;
+  const CKM_MD2_HMAC: number;
+  const CKM_MD2_HMAC_GENERAL: number;
+  const CKM_MD5: number;
+  const CKM_MD5_HMAC: number;
+  const CKM_MD5_HMAC_GENERAL: number;
+  const CKM_SHA_1: number;
+  const CKM_SHA_1_HMAC: number;
+  const CKM_SHA_1_HMAC_GENERAL: number;
+  const CKM_RIPEMD128: number;
+  const CKM_RIPEMD128_HMAC: number;
+  const CKM_RIPEMD128_HMAC_GENERAL: number;
+  const CKM_RIPEMD160: number;
+  const CKM_RIPEMD160_HMAC: number;
+  const CKM_RIPEMD160_HMAC_GENERAL: number;
+  const CKM_SHA256: number;
+  const CKM_SHA256_HMAC: number;
+  const CKM_SHA256_HMAC_GENERAL: number;
+  const CKM_SHA224: number;
+  const CKM_SHA224_HMAC: number;
+  const CKM_SHA224_HMAC_GENERAL: number;
+  const CKM_SHA384: number;
+  const CKM_SHA384_HMAC: number;
+  const CKM_SHA384_HMAC_GENERAL: number;
+  const CKM_SHA512: number;
+  const CKM_SHA512_HMAC: number;
+  const CKM_SHA512_HMAC_GENERAL: number;
+  const CKM_SECURID_KEY_GEN: number;
+  const CKM_SECURID: number;
+  const CKM_HOTP_KEY_GEN: number;
+  const CKM_HOTP: number;
+  const CKM_ACTI: number;
+  const CKM_ACTI_KEY_GEN: number;
+  const CKM_CAST_KEY_GEN: number;
+  const CKM_CAST_ECB: number;
+  const CKM_CAST_CBC: number;
+  const CKM_CAST_MAC: number;
+  const CKM_CAST_MAC_GENERAL: number;
+  const CKM_CAST_CBC_PAD: number;
+  const CKM_CAST3_KEY_GEN: number;
+  const CKM_CAST3_ECB: number;
+  const CKM_CAST3_CBC: number;
+  const CKM_CAST3_MAC: number;
+  const CKM_CAST3_MAC_GENERAL: number;
+  const CKM_CAST3_CBC_PAD: number;
+  const CKM_CAST5_KEY_GEN: number;
+  const CKM_CAST128_KEY_GEN: number;
+  const CKM_CAST5_ECB: number;
+  const CKM_CAST128_ECB: number;
+  const CKM_CAST5_CBC: number;
+  const CKM_CAST128_CBC: number;
+  const CKM_CAST5_MAC: number;
+  const CKM_CAST128_MAC: number;
+  const CKM_CAST5_MAC_GENERAL: number;
+  const CKM_CAST128_MAC_GENERAL: number;
+  const CKM_CAST5_CBC_PAD: number;
+  const CKM_CAST128_CBC_PAD: number;
+  const CKM_RC5_KEY_GEN: number;
+  const CKM_RC5_ECB: number;
+  const CKM_RC5_CBC: number;
+  const CKM_RC5_MAC: number;
+  const CKM_RC5_MAC_GENERAL: number;
+  const CKM_RC5_CBC_PAD: number;
+  const CKM_IDEA_KEY_GEN: number;
+  const CKM_IDEA_ECB: number;
+  const CKM_IDEA_CBC: number;
+  const CKM_IDEA_MAC: number;
+  const CKM_IDEA_MAC_GENERAL: number;
+  const CKM_IDEA_CBC_PAD: number;
+  const CKM_GENERIC_SECRET_KEY_GEN: number;
+  const CKM_CONCATENATE_BASE_AND_KEY: number;
+  const CKM_CONCATENATE_BASE_AND_DATA: number;
+  const CKM_CONCATENATE_DATA_AND_BASE: number;
+  const CKM_XOR_BASE_AND_DATA: number;
+  const CKM_EXTRACT_KEY_FROM_KEY: number;
+  const CKM_SSL3_PRE_MASTER_KEY_GEN: number;
+  const CKM_SSL3_MASTER_KEY_DERIVE: number;
+  const CKM_SSL3_KEY_AND_MAC_DERIVE: number;
+  const CKM_SSL3_MASTER_KEY_DERIVE_DH: number;
+  const CKM_TLS_PRE_MASTER_KEY_GEN: number;
+  const CKM_TLS_MASTER_KEY_DERIVE: number;
+  const CKM_TLS_KEY_AND_MAC_DERIVE: number;
+  const CKM_TLS_MASTER_KEY_DERIVE_DH: number;
+  const CKM_TLS_PRF: number;
+  const CKM_SSL3_MD5_MAC: number;
+  const CKM_SSL3_SHA1_MAC: number;
+  const CKM_MD5_KEY_DERIVATION: number;
+  const CKM_MD2_KEY_DERIVATION: number;
+  const CKM_SHA1_KEY_DERIVATION: number;
+  const CKM_SHA256_KEY_DERIVATION: number;
+  const CKM_SHA384_KEY_DERIVATION: number;
+  const CKM_SHA512_KEY_DERIVATION: number;
+  const CKM_SHA224_KEY_DERIVATION: number;
+  const CKM_PBE_MD2_DES_CBC: number;
+  const CKM_PBE_MD5_DES_CBC: number;
+  const CKM_PBE_MD5_CAST_CBC: number;
+  const CKM_PBE_MD5_CAST3_CBC: number;
+  const CKM_PBE_MD5_CAST5_CBC: number;
+  const CKM_PBE_MD5_CAST128_CBC: number;
+  const CKM_PBE_SHA1_CAST5_CBC: number;
+  const CKM_PBE_SHA1_CAST128_CBC: number;
+  const CKM_PBE_SHA1_RC4_128: number;
+  const CKM_PBE_SHA1_RC4_40: number;
+  const CKM_PBE_SHA1_DES3_EDE_CBC: number;
+  const CKM_PBE_SHA1_DES2_EDE_CBC: number;
+  const CKM_PBE_SHA1_RC2_128_CBC: number;
+  const CKM_PBE_SHA1_RC2_40_CBC: number;
+  const CKM_PKCS5_PBKD2: number;
+  const CKM_PBA_SHA1_WITH_SHA1_HMAC: number;
+  const CKM_WTLS_PRE_MASTER_KEY_GEN: number;
+  const CKM_WTLS_MASTER_KEY_DERIVE: number;
+  const CKM_WTLS_MASTER_KEY_DERIVE_DH_ECC: number;
+  const CKM_WTLS_PRF: number;
+  const CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE: number;
+  const CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE: number;
+  const CKM_KEY_WRAP_LYNKS: number;
+  const CKM_KEY_WRAP_SET_OAEP: number;
+  const CKM_CAMELLIA_KEY_GEN: number;
+  const CKM_CAMELLIA_ECB: number;
+  const CKM_CAMELLIA_CBC: number;
+  const CKM_CAMELLIA_MAC: number;
+  const CKM_CAMELLIA_MAC_GENERAL: number;
+  const CKM_CAMELLIA_CBC_PAD: number;
+  const CKM_CAMELLIA_ECB_ENCRYPT_DATA: number;
+  const CKM_CAMELLIA_CBC_ENCRYPT_DATA: number;
+  const CKM_CAMELLIA_CTR: number;
+  const CKM_ARIA_KEY_GEN: number;
+  const CKM_ARIA_ECB: number;
+  const CKM_ARIA_CBC: number;
+  const CKM_ARIA_MAC: number;
+  const CKM_ARIA_MAC_GENERAL: number;
+  const CKM_ARIA_CBC_PAD: number;
+  const CKM_ARIA_ECB_ENCRYPT_DATA: number;
+  const CKM_ARIA_CBC_ENCRYPT_DATA: number;
+  const CKM_SEED_KEY_GEN: number;
+  const CKM_SEED_ECB: number;
+  const CKM_SEED_CBC: number;
+  const CKM_SEED_MAC: number;
+  const CKM_SEED_MAC_GENERAL: number;
+  const CKM_SEED_CBC_PAD: number;
+  const CKM_SEED_ECB_ENCRYPT_DATA: number;
+  const CKM_SEED_CBC_ENCRYPT_DATA: number;
+  const CKM_SKIPJACK_KEY_GEN: number;
+  const CKM_SKIPJACK_ECB64: number;
+  const CKM_SKIPJACK_CBC64: number;
+  const CKM_SKIPJACK_OFB64: number;
+  const CKM_SKIPJACK_CFB64: number;
+  const CKM_SKIPJACK_CFB32: number;
+  const CKM_SKIPJACK_CFB16: number;
+  const CKM_SKIPJACK_CFB8: number;
+  const CKM_SKIPJACK_WRAP: number;
+  const CKM_SKIPJACK_PRIVATE_WRAP: number;
+  const CKM_SKIPJACK_RELAYX: number;
+  const CKM_KEA_KEY_PAIR_GEN: number;
+  const CKM_KEA_KEY_DERIVE: number;
+  const CKM_FORTEZZA_TIMESTAMP: number;
+  const CKM_BATON_KEY_GEN: number;
+  const CKM_BATON_ECB128: number;
+  const CKM_BATON_ECB96: number;
+  const CKM_BATON_CBC128: number;
+  const CKM_BATON_COUNTER: number;
+  const CKM_BATON_SHUFFLE: number;
+  const CKM_BATON_WRAP: number;
+  const CKM_ECDSA_KEY_PAIR_GEN: number;
+  const CKM_EC_KEY_PAIR_GEN: number;
+  const CKM_ECDSA: number;
+  const CKM_ECDSA_SHA1: number;
+  const CKM_ECDSA_SHA224: number;
+  const CKM_ECDSA_SHA256: number;
+  const CKM_ECDSA_SHA384: number;
+  const CKM_ECDSA_SHA512: number;
+  const CKM_ECDH1_DERIVE: number;
+  const CKM_ECDH1_COFACTOR_DERIVE: number;
+  const CKM_ECMQV_DERIVE: number;
+  const CKM_JUNIPER_KEY_GEN: number;
+  const CKM_JUNIPER_ECB128: number;
+  const CKM_JUNIPER_CBC128: number;
+  const CKM_JUNIPER_COUNTER: number;
+  const CKM_JUNIPER_SHUFFLE: number;
+  const CKM_JUNIPER_WRAP: number;
+  const CKM_FASTHASH: number;
+  const CKM_AES_KEY_GEN: number;
+  const CKM_AES_ECB: number;
+  const CKM_AES_CBC: number;
+  const CKM_AES_MAC: number;
+  const CKM_AES_MAC_GENERAL: number;
+  const CKM_AES_CBC_PAD: number;
+  const CKM_AES_CTR: number;
+  const CKM_AES_CTS: number;
+  const CKM_AES_CMAC: number;
+  const CKM_AES_CMAC_GENERAL: number;
+  const CKM_BLOWFISH_KEY_GEN: number;
+  const CKM_BLOWFISH_CBC: number;
+  const CKM_TWOFISH_KEY_GEN: number;
+  const CKM_TWOFISH_CBC: number;
+  const CKM_AES_GCM: number;
+  const CKM_AES_CCM: number;
+  const CKM_AES_KEY_WRAP: number;
+  const CKM_AES_KEY_WRAP_PAD: number;
+  const CKM_BLOWFISH_CBC_PAD: number;
+  const CKM_TWOFISH_CBC_PAD: number;
+  const CKM_DES_ECB_ENCRYPT_DATA: number;
+  const CKM_DES_CBC_ENCRYPT_DATA: number;
+  const CKM_DES3_ECB_ENCRYPT_DATA: number;
+  const CKM_DES3_CBC_ENCRYPT_DATA: number;
+  const CKM_AES_ECB_ENCRYPT_DATA: number;
+  const CKM_AES_CBC_ENCRYPT_DATA: number;
+  const CKM_GOSTR3410_KEY_PAIR_GEN: number;
+  const CKM_GOSTR3410: number;
+  const CKM_GOSTR3410_WITH_GOSTR3411: number;
+  const CKM_GOSTR3410_KEY_WRAP: number;
+  const CKM_GOSTR3410_DERIVE: number;
+  const CKM_GOSTR3411: number;
+  const CKM_GOSTR3411_HMAC: number;
+  const CKM_GOST28147_KEY_GEN: number;
+  const CKM_GOST28147_ECB: number;
+  const CKM_GOST28147: number;
+  const CKM_GOST28147_MAC: number;
+  const CKM_GOST28147_KEY_WRAP: number;
+  const CKM_DSA_PARAMETER_GEN: number;
+  const CKM_DH_PKCS_PARAMETER_GEN: number;
+  const CKM_X9_42_DH_PARAMETER_GEN: number;
+  const CKM_AES_OFB: number;
+  const CKM_AES_CFB64: number;
+  const CKM_AES_CFB8: number;
+  const CKM_AES_CFB128: number;
+  const CKM_RSA_PKCS_TPM_1_1: number;
+  const CKM_RSA_PKCS_OAEP_TPM_1_1: number;
+  const CKM_VENDOR_DEFINED: number;
+  //#endregion
+
+  //#region Session flags
+  const CKF_RW_SESSION: number;
+  const CKF_SERIAL_SESSION: number;
+  //#endregion
+
+  //#region Mechanism flags
+  const CKF_HW: number;
+  const CKF_ENCRYPT: number;
+  const CKF_DECRYPT: number;
+  const CKF_DIGEST: number;
+  const CKF_SIGN: number;
+  const CKF_SIGN_RECOVER: number;
+  const CKF_VERIFY: number;
+  const CKF_VERIFY_RECOVER: number;
+  const CKF_GENERATE: number;
+  const CKF_GENERATE_KEY_PAIR: number;
+  const CKF_WRAP: number;
+  const CKF_UNWRAP: number;
+  const CKF_DERIVE: number;
+  //#endregion
+
+  //#region Token Information Flags
+  const CKF_RNG: number;
+  const CKF_WRITE_PROTECTED: number;
+  const CKF_LOGIN_REQUIRED: number;
+  const CKF_USER_PIN_INITIALIZED: number;
+  const CKF_RESTORE_KEY_NOT_NEEDED: number;
+  const CKF_CLOCK_ON_TOKEN: number;
+  const CKF_PROTECTED_AUTHENTICATION_PATH: number;
+  const CKF_DUAL_CRYPTO_OPERATIONS: number;
+  const CKF_TOKEN_INITIALIZED: number;
+  const CKF_SECONDARY_AUTHENTICATION: number;
+  const CKF_USER_PIN_COUNT_LOW: number;
+  const CKF_USER_PIN_FINAL_TRY: number;
+  const CKF_USER_PIN_LOCKED: number;
+  const CKF_USER_PIN_TO_BE_CHANGED: number;
+  const CKF_SO_PIN_COUNT_LOW: number;
+  const CKF_SO_PIN_FINAL_TRY: number;
+  const CKF_SO_PIN_LOCKED: number;
+  const CKF_SO_PIN_TO_BE_CHANGED: number;
+  const CKF_ERROR_STATE: number;
+  //#endregion
+
+  //#region Event Flags
+  const CKF_DONT_BLOCK: number;
+  //#endregion
+
+  //#region Certificates
+  const CKC_X_509: number;
+  const CKC_X_509_ATTR_CERT: number;
+  const CKC_WTLS: number;
+  //#endregion
+
+  //#region MGFs
+  const CKG_MGF1_SHA1: number;
+  const CKG_MGF1_SHA256: number;
+  const CKG_MGF1_SHA384: number;
+  const CKG_MGF1_SHA512: number;
+  const CKG_MGF1_SHA224: number;
+  //#endregion
+
+  //#region KDFs
+  const CKD_NULL: number;
+  const CKD_SHA1_KDF: number;
+  const CKD_SHA1_KDF_ASN1: number;
+  const CKD_SHA1_KDF_CONCATENATE: number;
+  const CKD_SHA224_KDF: number;
+  const CKD_SHA256_KDF: number;
+  const CKD_SHA384_KDF: number;
+  const CKD_SHA512_KDF: number;
+  const CKD_CPDIVERSIFY_KDF: number;
+  //#endregion
+
+  //#region Mech params
+  const CK_PARAMS_AES_CBC: number;
+  const CK_PARAMS_AES_CCM: number;
+  const CK_PARAMS_AES_GCM: number;
+  const CK_PARAMS_RSA_OAEP: number;
+  const CK_PARAMS_RSA_PSS: number;
+  const CK_PARAMS_EC_DH: number;
+  const CK_PARAMS_AES_GCM_v240: number;
+  const CK_PARAMS_ECDH2_DERIVE: number;
+  const CK_PARAMS_ECMQV_DERIVE: number;
+  const CK_PARAMS_X9_42_DH1_DERIVE: number;
+  const CK_PARAMS_X9_42_DH2_DERIVE: number;
+  const CK_PARAMS_X9_42_MQV_DERIVE: number;
+  const CK_PARAMS_KEA_DERIVE: number;
+  const CK_PARAMS_RC2: number;
+  const CK_PARAMS_RC2_CBC: number;
+  const CK_PARAMS_RC2_MAC_GENERAL: number;
+  const CK_PARAMS_RC5: number;
+  const CK_PARAMS_RC5_CBC: number;
+  const CK_PARAMS_RC5_MAC_GENERAL: number;
+  const CK_PARAMS_DES_CBC_ENCRYPT_DATA: number;
+  const CK_PARAMS_SKIPJACK_PRIVATE_WRAP: number;
+  const CK_PARAMS_SKIPJACK_RELAYX: number;
+  const CK_PARAMS_PBE: number;
+  const CK_PARAMS_KEY_WRAP_SET_OAEP: number;
+  const CK_PARAMS_GCM: number;
+  const CK_PARAMS_CCM: number;
+  const CK_PARAM_GOSTR3410_DERIVE: number;
+  const CK_PARAM_GOSTR3410_KEY_WRAP: number;
+  //#endregion
+
+  //#region User types
+  const CKU_SO: number;
+  const CKU_USER: number;
+  const CKU_CONTEXT_SPECIFIC: number;
+  //#endregion
+
+  // Initialize flags
+  const CKF_LIBRARY_CANT_CREATE_OS_THREADS: number;
+  const CKF_OS_LOCKING_OK: number;
+
+  //#region Result values
+  const CKR_OK: number;
+  const CKR_CANCEL: number;
+  const CKR_HOST_MEMORY: number;
+  const CKR_SLOT_ID_INVALID: number;
+  const CKR_GENERAL_ERROR: number;
+  const CKR_FUNCTION_FAILED: number;
+  const CKR_ARGUMENTS_BAD: number;
+  const CKR_NO_EVENT: number;
+  const CKR_NEED_TO_CREATE_THREADS: number;
+  const CKR_CANT_LOCK: number;
+  const CKR_ATTRIBUTE_READ_ONLY: number;
+  const CKR_ATTRIBUTE_SENSITIVE: number;
+  const CKR_ATTRIBUTE_TYPE_INVALID: number;
+  const CKR_ATTRIBUTE_VALUE_INVALID: number;
+  const CKR_DATA_INVALID: number;
+  const CKR_DATA_LEN_RANGE: number;
+  const CKR_DEVICE_ERROR: number;
+  const CKR_DEVICE_MEMORY: number;
+  const CKR_DEVICE_REMOVED: number;
+  const CKR_ENCRYPTED_DATA_INVALID: number;
+  const CKR_ENCRYPTED_DATA_LEN_RANGE: number;
+  const CKR_FUNCTION_CANCELED: number;
+  const CKR_FUNCTION_NOT_PARALLEL: number;
+  const CKR_FUNCTION_NOT_SUPPORTED: number;
+  const CKR_KEY_HANDLE_INVALID: number;
+  const CKR_KEY_SIZE_RANGE: number;
+  const CKR_KEY_TYPE_INCONSISTENT: number;
+  const CKR_KEY_NOT_NEEDED: number;
+  const CKR_KEY_CHANGED: number;
+  const CKR_KEY_NEEDED: number;
+  const CKR_KEY_INDIGESTIBLE: number;
+  const CKR_KEY_FUNCTION_NOT_PERMITTED: number;
+  const CKR_KEY_NOT_WRAPPABLE: number;
+  const CKR_KEY_UNEXTRACTABLE: number;
+  const CKR_MECHANISM_INVALID: number;
+  const CKR_MECHANISM_PARAM_INVALID: number;
+  const CKR_OBJECT_HANDLE_INVALID: number;
+  const CKR_OPERATION_ACTIVE: number;
+  const CKR_OPERATION_NOT_INITIALIZED: number;
+  const CKR_PIN_INCORRECT: number;
+  const CKR_PIN_INVALID: number;
+  const CKR_PIN_LEN_RANGE: number;
+  const CKR_PIN_EXPIRED: number;
+  const CKR_PIN_LOCKED: number;
+  const CKR_SESSION_CLOSED: number;
+  const CKR_SESSION_COUNT: number;
+  const CKR_SESSION_HANDLE_INVALID: number;
+  const CKR_SESSION_PARALLEL_NOT_SUPPORTED: number;
+  const CKR_SESSION_READ_ONLY: number;
+  const CKR_SESSION_EXISTS: number;
+  const CKR_SESSION_READ_ONLY_EXISTS: number;
+  const CKR_SESSION_READ_WRITE_SO_EXISTS: number;
+  const CKR_SIGNATURE_INVALID: number;
+  const CKR_SIGNATURE_LEN_RANGE: number;
+  const CKR_TEMPLATE_INCOMPLETE: number;
+  const CKR_TEMPLATE_INCONSISTENT: number;
+  const CKR_TOKEN_NOT_PRESENT: number;
+  const CKR_TOKEN_NOT_RECOGNIZED: number;
+  const CKR_TOKEN_WRITE_PROTECTED: number;
+  const CKR_UNWRAPPING_KEY_HANDLE_INVALID: number;
+  const CKR_UNWRAPPING_KEY_SIZE_RANGE: number;
+  const CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT: number;
+  const CKR_USER_ALREADY_LOGGED_IN: number;
+  const CKR_USER_NOT_LOGGED_IN: number;
+  const CKR_USER_PIN_NOT_INITIALIZED: number;
+  const CKR_USER_TYPE_INVALID: number;
+  const CKR_USER_ANOTHER_ALREADY_LOGGED_IN: number;
+  const CKR_USER_TOO_MANY_TYPES: number;
+  const CKR_WRAPPED_KEY_INVALID: number;
+  const CKR_WRAPPED_KEY_LEN_RANGE: number;
+  const CKR_WRAPPING_KEY_HANDLE_INVALID: number;
+  const CKR_WRAPPING_KEY_SIZE_RANGE: number;
+  const CKR_WRAPPING_KEY_TYPE_INCONSISTENT: number;
+  const CKR_RANDOM_SEED_NOT_SUPPORTED: number;
+  const CKR_RANDOM_NO_RNG: number;
+  const CKR_DOMAIN_PARAMS_INVALID: number;
+  const CKR_BUFFER_TOO_SMALL: number;
+  const CKR_SAVED_STATE_INVALID: number;
+  const CKR_INFORMATION_SENSITIVE: number;
+  const CKR_STATE_UNSAVEABLE: number;
+  const CKR_CRYPTOKI_NOT_INITIALIZED: number;
+  const CKR_CRYPTOKI_ALREADY_INITIALIZED: number;
+  const CKR_MUTEX_BAD: number;
+  const CKR_MUTEX_NOT_LOCKED: number;
+  const CKR_NEW_PIN_MODE: number;
+  const CKR_NEXT_OTP: number;
+  const CKR_EXCEEDED_MAX_ITERATIONS: number;
+  const CKR_FIPS_SELF_TEST_FAILED: number;
+  const CKR_LIBRARY_LOAD_FAILED: number;
+  const CKR_PIN_TOO_WEAK: number;
+  const CKR_PUBLIC_KEY_INVALID: number;
+  const CKR_FUNCTION_REJECTED: number;
+  //#endregion
+
+  /**
+   * Exception from native module
+   */
+  class NativeError extends Error {
+    /**
+     * Native library call stack. Default is empty string
+     */
+    public readonly nativeStack: string;
+    /**
+     * Native function name. Default is empty string
+     */
+    public readonly method: string;
+    /**
+     * Initialize new instance of NativeError
+     * @param message Error message
+     */
+    public constructor(message?: string, method?: string);
+  }
+
+  /**
+   * Exception with the name and value of PKCS#11 return value
+   */
+  class Pkcs11Error extends NativeError {
+    /**
+     * PKCS#11 result value. Default is 0
+     */
+    public readonly code: number;
+    /**
+     * Initialize new instance of Pkcs11Error
+     * @param message Error message
+     * @param code PKCS#11 result value
+     * @param method The name of PKCS#11 method
+     */
+    public constructor(message?: string, code?: number, method?: string);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,124 +9,77 @@
       "version": "2.1.5",
       "license": "MIT",
       "devDependencies": {
-        "@types/mocha": "^9.1.0",
-        "@types/node": "^17.0.15",
-        "coveralls": "^3.1.1",
-        "mocha": "^9.2.0",
-        "nyc": "^15.1.0",
-        "typedoc": "^0.22.11",
-        "typescript": "^4.5.5"
+        "@types/mocha": "^10.0.7",
+        "@types/node": "^22.5.1",
+        "mocha": "^10.7.3",
+        "nyc": "^17.0.0",
+        "typedoc": "^0.26.6",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/PeculiarVentures"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "dev": true,
       "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.0",
+        "@babel/helper-compilation-targets": "^7.25.2",
+        "@babel/helper-module-transforms": "^7.25.2",
+        "@babel/helpers": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.2",
+        "@babel/types": "^7.25.2",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -136,179 +89,137 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "version": "7.25.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.25.4",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/compat-data": "^7.25.2",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -386,10 +297,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
       "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.25.4"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -398,33 +312,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.4",
+        "@babel/parser": "^7.25.4",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.4",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -433,13 +344,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -524,69 +435,90 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.14.1.tgz",
+      "integrity": "sha512-KyHIIpKNaT20FtFPFjCQB5WVSTpLR/n+jQXhWHWVUMm9MaOaG9BGOG0MSyt7yA4+Lm+4c9rTc03tt3nYzeYSfw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
+      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
-      "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==",
-      "dev": true
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
+      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "node_modules/aggregate-error": {
@@ -602,26 +534,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -691,59 +607,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -765,12 +633,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -781,6 +649,38 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -806,11 +706,25 @@
         "node": ">=6"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001653",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+      "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -905,18 +819,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -930,38 +832,10 @@
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
-    },
-    "node_modules/coveralls": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
-      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
-      "dev": true,
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      },
-      "bin": {
-        "coveralls": "bin/coveralls.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -977,22 +851,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1033,39 +895,38 @@
         "node": ">=8"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -1074,9 +935,9 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1107,37 +968,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1199,29 +1033,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/fromentries": {
@@ -1291,15 +1102,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1347,38 +1149,6 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1418,21 +1188,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -1570,16 +1325,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1598,18 +1347,31 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
@@ -1711,12 +1473,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -1728,24 +1484,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1759,34 +1497,13 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
-      "dev": true
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true,
-      "bin": {
-        "lcov-parse": "bin/cli.js"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -1804,26 +1521,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "node_modules/log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.6"
-      }
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1839,6 +1541,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lunr": {
@@ -1862,38 +1573,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.45.0"
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">= 0.6"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1907,53 +1614,39 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/mocha/node_modules/argparse": {
@@ -1961,6 +1654,35 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mocha/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1975,12 +1697,12 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -1991,18 +1713,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -2016,6 +1726,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "dev": true
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2026,9 +1742,9 @@
       }
     },
     "node_modules/nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.0.0.tgz",
+      "integrity": "sha512-ISp44nqNCaPugLLGGfknzQwSwt10SSS5IMoPR7GLoMAyS18Iw5js8U7ga2VF9lYuMZ42gOHr3UddZw4WZltxKg==",
       "dev": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2043,7 +1759,7 @@
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
@@ -2063,7 +1779,7 @@
         "nyc": "bin/nyc.js"
       },
       "engines": {
-        "node": ">=8.9"
+        "node": ">=18"
       }
     },
     "node_modules/nyc/node_modules/cliui": {
@@ -2184,15 +1900,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2295,10 +2002,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+    "node_modules/picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -2389,28 +2096,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/randombytes": {
@@ -2444,38 +2136,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -2523,12 +2183,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2539,9 +2193,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -2575,14 +2229,13 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
-      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.14.1.tgz",
+      "integrity": "sha512-FujAN40NEejeXdzPt+3sZ3F2dx1U24BY2XTY01+MG8mbxCiA2XukXdcbyMyLAHJ/1AUUnQd1tZlvIjefWWEJeA==",
       "dev": true,
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "@shikijs/core": "1.14.1",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/signal-exit": {
@@ -2590,15 +2243,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
@@ -2622,26 +2266,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2722,7 +2346,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2739,37 +2363,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
@@ -2790,47 +2383,104 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
-      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "version": "0.26.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.6.tgz",
+      "integrity": "sha512-SfEU3SH3wHNaxhFPjaZE2kNl/NFtLNW5c1oHsg7mti7GjmUj1Roq6osBQeMd+F4kL0BoRBBr8gQAuqBlfFu8LA==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.10",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.10.0"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.9.1",
+        "yaml": "^2.4.5"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "punycode": "^2.1.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uuid": {
@@ -2841,32 +2491,6 @@
       "bin": {
         "uuid": "bin/uuid"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
-      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2890,9 +2514,9 @@
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -2939,6 +2563,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -2958,9 +2600,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -3019,248 +2661,158 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+    "@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "@babel/core": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.16.tgz",
-      "integrity": "sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==",
+    "@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.15",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helpers": "^7.12.13",
-        "@babel/parser": "^7.12.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "convert-source-map": "^1.7.0",
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.0",
+        "@babel/helper-compilation-targets": "^7.25.2",
+        "@babel/helper-module-transforms": "^7.25.2",
+        "@babel/helpers": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.2",
+        "@babel/types": "^7.25.2",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "version": "7.25.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.25.4",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       }
     },
-    "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true
-    },
-    "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+    "@babel/helper-compilation-targets": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/compat-data": "^7.25.2",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
-        "@babel/helper-simple-access": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.2"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3322,48 +2874,48 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/types": "^7.25.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.4",
+        "@babel/parser": "^7.25.4",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.4",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -3426,60 +2978,81 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
       "requires": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true
     },
     "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@shikijs/core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.14.1.tgz",
+      "integrity": "sha512-KyHIIpKNaT20FtFPFjCQB5WVSTpLR/n+jQXhWHWVUMm9MaOaG9BGOG0MSyt7yA4+Lm+4c9rTc03tt3nYzeYSfw==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
+      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
-      "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==",
-      "dev": true
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
+      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "aggregate-error": {
@@ -3492,22 +3065,10 @@
         "indent-string": "^4.0.0"
       }
     },
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
     "ansi-regex": {
@@ -3559,53 +3120,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -3624,12 +3143,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-stdout": {
@@ -3637,6 +3156,18 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "browserslist": {
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
+      }
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -3656,10 +3187,10 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+    "caniuse-lite": {
+      "version": "1.0.30001653",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+      "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
       "dev": true
     },
     "chalk": {
@@ -3731,15 +3262,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3753,32 +3275,10 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
-    },
-    "coveralls": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
-      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -3791,19 +3291,10 @@
         "which": "^2.0.1"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -3832,32 +3323,28 @@
         "strip-bom": "^4.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
+    "electron-to-chromium": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
     },
     "es6-error": {
@@ -3867,9 +3354,9 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -3884,34 +3371,10 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -3954,23 +3417,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fromentries": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
@@ -4008,15 +3454,6 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4052,28 +3489,6 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4101,17 +3516,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4213,16 +3617,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -4235,15 +3633,24 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -4328,34 +3735,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -4364,29 +3747,14 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
-    "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
-      "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
+        "uc.micro": "^2.0.0"
       }
-    },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -4397,22 +3765,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -4423,6 +3779,15 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
       }
     },
     "lunr": {
@@ -4440,26 +3805,33 @@
         "semver": "^6.0.0"
       }
     },
-    "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+    "markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.45.0"
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        }
       }
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -4470,42 +3842,32 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "dependencies": {
         "argparse": {
@@ -4513,6 +3875,28 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -4524,12 +3908,12 @@
           }
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         }
       }
@@ -4538,12 +3922,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "node-preload": {
@@ -4555,6 +3933,12 @@
         "process-on-spawn": "^1.0.0"
       }
     },
+    "node-releases": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "dev": true
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4562,9 +3946,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.0.0.tgz",
+      "integrity": "sha512-ISp44nqNCaPugLLGGfknzQwSwt10SSS5IMoPR7GLoMAyS18Iw5js8U7ga2VF9lYuMZ42gOHr3UddZw4WZltxKg==",
       "dev": true,
       "requires": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -4579,7 +3963,7 @@
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
@@ -4692,12 +4076,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4770,10 +4148,10 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+    "picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "picomatch": {
@@ -4839,22 +4217,10 @@
         "fromentries": "^1.2.0"
       }
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
     "randombytes": {
@@ -4882,34 +4248,6 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
-      }
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -4945,12 +4283,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4958,9 +4290,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -4988,26 +4320,19 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
-      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.14.1.tgz",
+      "integrity": "sha512-FujAN40NEejeXdzPt+3sZ3F2dx1U24BY2XTY01+MG8mbxCiA2XukXdcbyMyLAHJ/1AUUnQd1tZlvIjefWWEJeA==",
       "dev": true,
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "@shikijs/core": "1.14.1",
+        "@types/hast": "^3.0.4"
       }
     },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "spawn-wrap": {
@@ -5029,23 +4354,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -5102,7 +4410,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -5113,31 +4421,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",
@@ -5155,60 +4438,70 @@
       }
     },
     "typedoc": {
-      "version": "0.22.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
-      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "version": "0.26.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.6.tgz",
+      "integrity": "sha512-SfEU3SH3wHNaxhFPjaZE2kNl/NFtLNW5c1oHsg7mti7GjmUj1Roq6osBQeMd+F4kL0BoRBBr8gQAuqBlfFu8LA==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.10",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.10.0"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.9.1",
+        "yaml": "^2.4.5"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       }
     },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "vscode-oniguruma": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
-      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
-      "dev": true
-    },
-    "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "which": {
@@ -5227,9 +4520,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true
     },
     "wrap-ansi": {
@@ -5267,6 +4560,18 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "dev": true
+    },
     "yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -5283,9 +4588,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yargs-unparser": {

--- a/package.json
+++ b/package.json
@@ -46,13 +46,12 @@
   "author": "PeculiarVentures",
   "license": "MIT",
   "devDependencies": {
-    "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.15",
-    "coveralls": "^3.1.1",
-    "mocha": "^9.2.0",
-    "nyc": "^15.1.0",
-    "typedoc": "^0.22.11",
-    "typescript": "^4.5.5"
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^22.5.1",
+    "mocha": "^10.7.3",
+    "nyc": "^17.0.0",
+    "typedoc": "^0.26.6",
+    "typescript": "^5.5.4"
   },
   "bugs": {
     "url": "https://github.com/PeculiarVentures/pkcs11js/issues"


### PR DESCRIPTION
This pull request primarily addresses a critical bug fix where the code was not handling cases where the pkcs11 module may return `slotCount` 0 on the first call to `C_GetSlotList`, and a non-zero value on subsequent calls. This issue led to a segmentation fault when using `pSlotList`. The fix involves checking if `slotCount` is 0 and returning an empty array if no slots are available.

Additionally, this pull request includes:
- Updates to the Coveralls GitHub action to version 2.
- Updates to the npm dependencies to their latest versions.